### PR TITLE
Port allocation tags to 1.5.0

### DIFF
--- a/Finova/AppFlowController.swift
+++ b/Finova/AppFlowController.swift
@@ -397,6 +397,42 @@ extension AppFlowController: BudgetsFlowDelegate {
     func navBackToDashboard() {
         navigationController?.popViewController(animated: true)
     }
+
+    func navigateToAllocationTags() {
+        let viewController = viewControllersFactory.makeAllocationTagsViewController(flowDelegate: self)
+        navigationController?.pushViewController(viewController, animated: true)
+    }
+}
+
+// MARK: - Allocation Tags Flow
+extension AppFlowController: AllocationTagsFlowDelegate {
+    func dismissAllocationTags() {
+        navigationController?.popViewController(animated: true)
+    }
+
+    func navigateToAllocationTagEdit(tag: AllocationTag) {
+        let viewController = viewControllersFactory.makeAllocationTagEditViewController(
+            flowDelegate: self, tag: tag)
+        navigationController?.pushViewController(viewController, animated: true)
+    }
+}
+
+extension AppFlowController: AllocationTagEditFlowDelegate {
+    func dismissAllocationTagEdit() {
+        navigationController?.popViewController(animated: true)
+    }
+
+    func navigateToAllocationTagCategories(tag: AllocationTag) {
+        let viewController = viewControllersFactory.makeAllocationTagCategoriesViewController(
+            flowDelegate: self, tag: tag)
+        navigationController?.pushViewController(viewController, animated: true)
+    }
+}
+
+extension AppFlowController: AllocationTagCategoriesFlowDelegate {
+    func dismissAllocationTagCategories() {
+        navigationController?.popViewController(animated: true)
+    }
 }
 
 // MARK: - Add Transaction Modal Flow

--- a/Finova/AppFlowController.swift
+++ b/Finova/AppFlowController.swift
@@ -405,6 +405,18 @@ extension AppFlowController: BudgetsFlowDelegate {
 }
 
 // MARK: - Allocation Tags Flow
+extension AppFlowController {
+    /// Reached from the `+` chip at the end of the dashboard's tag strip. Uses the same prompt as the
+    /// Tags list and lands in the same place - the edit screen - because a tag with no linked categories
+    /// changes nothing on the card the user just tapped from.
+    func presentCreateAllocationTag() {
+        guard let presenter = navigationController?.topViewController else { return }
+        AllocationTagCreationPrompt.present(from: presenter) { [weak self] tag in
+            self?.navigateToAllocationTagEdit(tag: tag)
+        }
+    }
+}
+
 extension AppFlowController: AllocationTagsFlowDelegate {
     func dismissAllocationTags() {
         navigationController?.popViewController(animated: true)

--- a/Finova/Resources/Localizable.xcstrings
+++ b/Finova/Resources/Localizable.xcstrings
@@ -192,23 +192,6 @@
         }
       }
     },
-    "addCreditCard.input.creditLimit": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Credit Limit (optional)"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Limite de Crédito (opcional)"
-          }
-        }
-      }
-    },
     "addCreditCard.input.defaultCard": {
       "extractionState": "manual",
       "localizations": {
@@ -239,6 +222,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "Pré-selecionar este cartão ao adicionar transações"
+          }
+        }
+      }
+    },
+    "addCreditCard.input.creditLimit": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Credit Limit (optional)"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limite de Crédito (opcional)"
           }
         }
       }
@@ -617,23 +617,6 @@
         }
       }
     },
-    "addTransactionModal.paymentMethod.createCard": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Create Card"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Criar Cartão"
-          }
-        }
-      }
-    },
     "addTransactionModal.paymentMethod.creditCard": {
       "extractionState": "manual",
       "localizations": {
@@ -698,6 +681,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "Toque para adicionar um cartão"
+          }
+        }
+      }
+    },
+    "addTransactionModal.paymentMethod.createCard": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Create Card"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Criar Cartão"
           }
         }
       }
@@ -2011,465 +2011,6 @@
         }
       }
     },
-    "allocationTags.categories.inOtherTag": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "In %@"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Em %@"
-          }
-        }
-      }
-    },
-    "allocationTags.categories.move.button": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Move"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mover"
-          }
-        }
-      }
-    },
-    "allocationTags.categories.move.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$@ is currently in %2$@. It can belong to one tag at a time."
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$@ está em %2$@. Ela pode pertencer a apenas uma etiqueta por vez."
-          }
-        }
-      }
-    },
-    "allocationTags.categories.move.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Move category?"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mover categoria?"
-          }
-        }
-      }
-    },
-    "allocationTags.categories.subtitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pick the categories this tag covers"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Escolha as categorias que esta etiqueta cobre"
-          }
-        }
-      }
-    },
-    "allocationTags.categories.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Categories"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Categorias"
-          }
-        }
-      }
-    },
-    "allocationTags.create.button": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Create"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Criar"
-          }
-        }
-      }
-    },
-    "allocationTags.create.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Name this group of categories"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dê um nome a este grupo de categorias"
-          }
-        }
-      }
-    },
-    "allocationTags.create.namePlaceholder": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Essentials"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Essenciais"
-          }
-        }
-      }
-    },
-    "allocationTags.create.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "New tag"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nova etiqueta"
-          }
-        }
-      }
-    },
-    "allocationTags.delete.confirm": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Delete"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Excluir"
-          }
-        }
-      }
-    },
-    "allocationTags.delete.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Only the grouping is removed. Your allocations and transactions are untouched."
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Apenas o agrupamento é removido. Suas alocações e transações não são afetadas."
-          }
-        }
-      }
-    },
-    "allocationTags.delete.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Delete tag?"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Excluir etiqueta?"
-          }
-        }
-      }
-    },
-    "allocationTags.edit.categories.row": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Categories"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Categorias"
-          }
-        }
-      }
-    },
-    "allocationTags.edit.delete.button": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Delete tag"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Excluir etiqueta"
-          }
-        }
-      }
-    },
-    "allocationTags.edit.error.name.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Give this tag a name so you can recognise it."
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dê um nome a esta etiqueta para poder reconhecê-la."
-          }
-        }
-      }
-    },
-    "allocationTags.edit.error.name.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Name required"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nome obrigatório"
-          }
-        }
-      }
-    },
-    "allocationTags.edit.input.color": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Color"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cor"
-          }
-        }
-      }
-    },
-    "allocationTags.edit.input.icon": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Icon"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ícone"
-          }
-        }
-      }
-    },
-    "allocationTags.edit.input.name": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Name"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nome"
-          }
-        }
-      }
-    },
-    "allocationTags.edit.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Edit tag"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Editar etiqueta"
-          }
-        }
-      }
-    },
-    "allocationTags.emptyState.description": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No tags yet. Create one to group your categories."
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nenhuma etiqueta ainda. Crie uma para agrupar suas categorias."
-          }
-        }
-      }
-    },
-    "allocationTags.row.categoryCount": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%d categories"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%d categorias"
-          }
-        }
-      }
-    },
-    "allocationTags.row.categoryCount.one": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "1 category"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "1 categoria"
-          }
-        }
-      }
-    },
-    "allocationTags.row.noCategories": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No categories yet"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nenhuma categoria ainda"
-          }
-        }
-      }
-    },
-    "allocationTags.subtitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Group categories to see what a set costs"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Agrupe categorias para ver quanto um conjunto custa"
-          }
-        }
-      }
-    },
-    "allocationTags.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Allocation tags"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Etiquetas de alocação"
-          }
-        }
-      }
-    },
     "auth.dialog.accountFound.message": {
       "extractionState": "manual",
       "localizations": {
@@ -2946,6 +2487,23 @@
         }
       }
     },
+    "biometrics.generic.name": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Biometrics"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Biometria"
+          }
+        }
+      }
+    },
     "biometric.error.authenticationFailed": {
       "extractionState": "manual",
       "localizations": {
@@ -2997,23 +2555,6 @@
         }
       }
     },
-    "biometrics.generic.name": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Biometrics"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Biometria"
-          }
-        }
-      }
-    },
     "budget.allocated.label": {
       "extractionState": "manual",
       "localizations": {
@@ -3061,23 +2602,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Nenhuma alocação de orçamento para este mês"
-          }
-        }
-      }
-    },
-    "budget.allocations.emptyState.filtered": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No allocations in this tag"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nenhuma alocação nesta etiqueta"
           }
         }
       }
@@ -3286,23 +2810,6 @@
         }
       }
     },
-    "budget.projection.saved.format": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ saved"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ economizado"
-          }
-        }
-      }
-    },
     "budget.projection.saved.label": {
       "extractionState": "manual",
       "localizations": {
@@ -3350,57 +2857,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "acima"
-          }
-        }
-      }
-    },
-    "budget.tag.shareOfBudget": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%d%% of budget"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%d%% do orçamento"
-          }
-        }
-      }
-    },
-    "budget.tags.strip.clear": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Clear filter"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Limpar filtro"
-          }
-        }
-      }
-    },
-    "budget.tags.strip.untagged": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Untagged"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sem etiqueta"
           }
         }
       }
@@ -3660,227 +3116,6 @@
         }
       }
     },
-    "budgets.tags.manage": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tags"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Etiquetas"
-          }
-        }
-      }
-    },
-    "cancellation.confirm.action": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancel purchase"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancelar compra"
-          }
-        }
-      }
-    },
-    "cancellation.confirm.message.plural": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A credit of %2$@ will be added to your next statement, covering the %1$d installments still to be billed.\n\nThose installments keep being charged as scheduled, so the two cancel each other out."
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Um crédito de %2$@ será adicionado à sua próxima fatura, cobrindo as %1$d parcelas que ainda serão cobradas.\n\nEssas parcelas continuam sendo cobradas normalmente, então as duas se anulam."
-          }
-        }
-      }
-    },
-    "cancellation.confirm.message.singular": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A credit of %2$@ will be added to your next statement, covering the %1$d installment still to be billed.\n\nThe installment keeps being charged as scheduled, so the two cancel each other out."
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Um crédito de %2$@ será adicionado à sua próxima fatura, cobrindo a %1$d parcela que ainda será cobrada.\n\nA parcela continua sendo cobrada normalmente, então as duas se anulam."
-          }
-        }
-      }
-    },
-    "cancellation.confirm.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancel this purchase?"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancelar esta compra?"
-          }
-        }
-      }
-    },
-    "cancellation.details.note": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "These installments keep being charged on their original statements. This credit covers their total, so the net effect over time is zero."
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Estas parcelas continuam sendo cobradas nas faturas originais. Este crédito cobre o total delas, então o efeito final é zero."
-          }
-        }
-      }
-    },
-    "cancellation.details.refunded.header": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Installments refunded"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Parcelas estornadas"
-          }
-        }
-      }
-    },
-    "cancellation.entry.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancel purchase"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancelar compra"
-          }
-        }
-      }
-    },
-    "cancellation.error.generic": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The purchase could not be cancelled. Nothing was changed."
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Não foi possível cancelar a compra. Nada foi alterado."
-          }
-        }
-      }
-    },
-    "cancellation.transaction.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancellation refund — %@"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Estorno — %@"
-          }
-        }
-      }
-    },
-    "cancellation.undo.action": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Undo"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Desfazer"
-          }
-        }
-      }
-    },
-    "cancellation.undo.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The credit will be removed and the purchase will no longer be marked as cancelled."
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "O crédito será removido e a compra deixará de ficar marcada como cancelada."
-          }
-        }
-      }
-    },
-    "cancellation.undo.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Undo cancellation"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Desfazer cancelamento"
-          }
-        }
-      }
-    },
     "cardBrand.amex": {
       "extractionState": "manual",
       "localizations": {
@@ -4000,6 +3235,23 @@
         }
       }
     },
+    "category.creditCard": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Credit Card"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cartão de Crédito"
+          }
+        }
+      }
+    },
     "category.clothing": {
       "extractionState": "manual",
       "localizations": {
@@ -4047,23 +3299,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Crédito"
-          }
-        }
-      }
-    },
-    "category.creditCard": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Credit Card"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cartão de Crédito"
           }
         }
       }
@@ -4561,23 +3796,6 @@
         }
       }
     },
-    "creditCards.cell.currentStatement": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Current: %@"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Atual: %@"
-          }
-        }
-      }
-    },
     "creditCards.cell.default": {
       "extractionState": "manual",
       "localizations": {
@@ -4591,6 +3809,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "PADRÃO"
+          }
+        }
+      }
+    },
+    "creditCards.cell.currentStatement": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Current: %@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atual: %@"
           }
         }
       }
@@ -4795,550 +4030,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Tem certeza?"
-          }
-        }
-      }
-    },
-    "earlyPayment.badge.settled": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Paid early"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Antecipada"
-          }
-        }
-      }
-    },
-    "earlyPayment.button.continue": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Continue"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Continuar"
-          }
-        }
-      }
-    },
-    "earlyPayment.confirm.action": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Confirm"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Confirmar"
-          }
-        }
-      }
-    },
-    "earlyPayment.confirm.destination.standalone": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Will be recorded as a separate debit, outside the card."
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Será registrado como um débito separado, fora do cartão."
-          }
-        }
-      }
-    },
-    "earlyPayment.confirm.destination.statement": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Will be added to the open statement of %@."
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Será adicionado à fatura aberta do %@."
-          }
-        }
-      }
-    },
-    "earlyPayment.confirm.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$d installment(s), %2$@, on %3$@.\n\n%4$@"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$d parcela(s), %2$@, em %3$@.\n\n%4$@"
-          }
-        }
-      }
-    },
-    "earlyPayment.confirm.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Confirm early payment"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Confirmar antecipação"
-          }
-        }
-      }
-    },
-    "earlyPayment.date.label": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Payment date"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Data do pagamento"
-          }
-        }
-      }
-    },
-    "earlyPayment.destination.label": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Charge to"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lançar em"
-          }
-        }
-      }
-    },
-    "earlyPayment.destination.openStatement": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Card's open statement"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fatura aberta do cartão"
-          }
-        }
-      }
-    },
-    "earlyPayment.destination.standalone": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Outside the card"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fora do cartão"
-          }
-        }
-      }
-    },
-    "earlyPayment.destination.standalone.subtitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A separate debit on the chosen date"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Um débito separado na data escolhida"
-          }
-        }
-      }
-    },
-    "earlyPayment.details.included.header": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Installments included"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Parcelas incluídas"
-          }
-        }
-      }
-    },
-    "earlyPayment.empty": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This series has no future installments left to pay early."
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Esta compra não tem mais parcelas futuras para antecipar."
-          }
-        }
-      }
-    },
-    "earlyPayment.entry.count.plural": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%d available"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%d disponíveis"
-          }
-        }
-      }
-    },
-    "earlyPayment.entry.count.singular": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%d available"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%d disponível"
-          }
-        }
-      }
-    },
-    "earlyPayment.entry.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pay installments early"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Antecipar parcelas"
-          }
-        }
-      }
-    },
-    "earlyPayment.error.generic": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The early payment could not be completed. Nothing was changed."
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Não foi possível concluir a antecipação. Nada foi alterado."
-          }
-        }
-      }
-    },
-    "earlyPayment.footer.count.plural": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%d installments selected"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%d parcelas selecionadas"
-          }
-        }
-      }
-    },
-    "earlyPayment.footer.count.singular": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%d installment selected"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%d parcela selecionada"
-          }
-        }
-      }
-    },
-    "earlyPayment.footer.total": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Amount paid early"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Valor antecipado"
-          }
-        }
-      }
-    },
-    "earlyPayment.header.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pay installments early"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Antecipar parcelas"
-          }
-        }
-      }
-    },
-    "earlyPayment.installmentRow": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Installment %d of %d (%@)"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Parcela %d de %d (%@)"
-          }
-        }
-      }
-    },
-    "earlyPayment.installments.header": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Future installments"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Parcelas futuras"
-          }
-        }
-      }
-    },
-    "earlyPayment.intro": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Choose the installments of “%@” you want to pay early. Each one you select stops counting toward its own month."
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Escolha as parcelas de “%@” que você quer antecipar. Cada parcela selecionada deixa de contar no mês dela."
-          }
-        }
-      }
-    },
-    "earlyPayment.label.remaining": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Remaining"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Restante"
-          }
-        }
-      }
-    },
-    "earlyPayment.payment.header": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Payment"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pagamento"
-          }
-        }
-      }
-    },
-    "earlyPayment.selectAll": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Select all"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Selecionar tudo"
-          }
-        }
-      }
-    },
-    "earlyPayment.transaction.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Early payment — %@"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Antecipação — %@"
-          }
-        }
-      }
-    },
-    "earlyPayment.undo.action": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Undo"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Desfazer"
-          }
-        }
-      }
-    },
-    "earlyPayment.undo.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The installments will go back to their original statements and this debit will be deleted."
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "As parcelas voltarão para as faturas originais e este débito será excluído."
-          }
-        }
-      }
-    },
-    "earlyPayment.undo.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Undo early payment"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Desfazer antecipação"
           }
         }
       }
@@ -7298,74 +5989,6 @@
         }
       }
     },
-    "notification.statement.dueSoon.body": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your %@ statement of %@ is due in 3 days"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sua fatura do %@ de %@ vence em 3 dias"
-          }
-        }
-      }
-    },
-    "notification.statement.dueSoon.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Statement Due Soon"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fatura Vencendo em Breve"
-          }
-        }
-      }
-    },
-    "notification.statement.paymentDue.body": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your %@ statement of %@ is due today. Don't forget to pay!"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sua fatura do %@ de %@ vence hoje. Não esqueça de pagar!"
-          }
-        }
-      }
-    },
-    "notification.statement.paymentDue.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Payment Due Today"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pagamento Vence Hoje"
-          }
-        }
-      }
-    },
     "notification.test.body": {
       "extractionState": "manual",
       "localizations": {
@@ -7498,6 +6121,74 @@
           "stringUnit": {
             "state": "translated",
             "value": "Crédito agendado"
+          }
+        }
+      }
+    },
+    "notification.statement.dueSoon.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Statement Due Soon"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fatura Vencendo em Breve"
+          }
+        }
+      }
+    },
+    "notification.statement.dueSoon.body": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your %@ statement of %@ is due in 3 days"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sua fatura do %@ de %@ vence em 3 dias"
+          }
+        }
+      }
+    },
+    "notification.statement.paymentDue.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Payment Due Today"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pagamento Vence Hoje"
+          }
+        }
+      }
+    },
+    "notification.statement.paymentDue.body": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your %@ statement of %@ is due today. Don't forget to pay!"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sua fatura do %@ de %@ vence hoje. Não esqueça de pagar!"
           }
         }
       }
@@ -7655,40 +6346,6 @@
         }
       }
     },
-    "notificationSettings.creditCardStatement.description": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reminders for upcoming statement due dates"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lembretes para datas de vencimento de faturas"
-          }
-        }
-      }
-    },
-    "notificationSettings.creditCardStatement.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Credit Card Statements"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Faturas de Cartão"
-          }
-        }
-      }
-    },
     "notificationSettings.disableAll.description": {
       "extractionState": "manual",
       "localizations": {
@@ -7770,6 +6427,40 @@
           "stringUnit": {
             "state": "translated",
             "value": "Aviso de Saldo Negativo"
+          }
+        }
+      }
+    },
+    "notificationSettings.creditCardStatement.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Credit Card Statements"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Faturas de Cartão"
+          }
+        }
+      }
+    },
+    "notificationSettings.creditCardStatement.description": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reminders for upcoming statement due dates"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lembretes para datas de vencimento de faturas"
           }
         }
       }
@@ -7961,23 +6652,6 @@
         }
       }
     },
-    "profile.creditCards.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Credit Cards"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cartões de Crédito"
-          }
-        }
-      }
-    },
     "profile.header.title": {
       "extractionState": "manual",
       "localizations": {
@@ -7991,74 +6665,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Minha Conta"
-          }
-        }
-      }
-    },
-    "profile.logout.confirm.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Are you sure you want to logout?"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tem certeza que deseja sair?"
-          }
-        }
-      }
-    },
-    "profile.logout.confirm.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Logout"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sair"
-          }
-        }
-      }
-    },
-    "profile.logout.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Logout"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sair"
-          }
-        }
-      }
-    },
-    "profile.section.account": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Account"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Conta"
           }
         }
       }
@@ -8097,6 +6703,40 @@
         }
       }
     },
+    "profile.section.account": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Account"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conta"
+          }
+        }
+      }
+    },
+    "profile.creditCards.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Credit Cards"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cartões de Crédito"
+          }
+        }
+      }
+    },
     "profile.settings.title": {
       "extractionState": "manual",
       "localizations": {
@@ -8110,6 +6750,57 @@
           "stringUnit": {
             "state": "translated",
             "value": "Configurações"
+          }
+        }
+      }
+    },
+    "profile.logout.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Logout"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sair"
+          }
+        }
+      }
+    },
+    "profile.logout.confirm.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Logout"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sair"
+          }
+        }
+      }
+    },
+    "profile.logout.confirm.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Are you sure you want to logout?"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tem certeza que deseja sair?"
           }
         }
       }
@@ -8913,6 +7604,23 @@
         }
       }
     },
+    "statementDetails.dueDate": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Due Date"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Data de Vencimento"
+          }
+        }
+      }
+    },
     "statementDetails.card": {
       "extractionState": "manual",
       "localizations": {
@@ -8943,23 +7651,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Data de Fechamento"
-          }
-        }
-      }
-    },
-    "statementDetails.dueDate": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Due Date"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Data de Vencimento"
           }
         }
       }
@@ -9491,23 +8182,6 @@
         }
       }
     },
-    "transactionDetails.label.paymentMethod": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Payment method"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Método de pagamento"
-          }
-        }
-      }
-    },
     "transactionDetails.label.totalValue": {
       "extractionState": "manual",
       "localizations": {
@@ -9538,6 +8212,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "Tipo"
+          }
+        }
+      }
+    },
+    "transactionDetails.label.paymentMethod": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Payment method"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Método de pagamento"
           }
         }
       }
@@ -9827,6 +8518,1315 @@
           "stringUnit": {
             "state": "translated",
             "value": "Sim"
+          }
+        }
+      }
+    },
+    "cancellation.confirm.action": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel purchase"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar compra"
+          }
+        }
+      }
+    },
+    "cancellation.confirm.message.plural": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A credit of %2$@ will be added to your next statement, covering the %1$d installments still to be billed.\n\nThose installments keep being charged as scheduled, so the two cancel each other out."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Um crédito de %2$@ será adicionado à sua próxima fatura, cobrindo as %1$d parcelas que ainda serão cobradas.\n\nEssas parcelas continuam sendo cobradas normalmente, então as duas se anulam."
+          }
+        }
+      }
+    },
+    "cancellation.confirm.message.singular": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A credit of %2$@ will be added to your next statement, covering the %1$d installment still to be billed.\n\nThe installment keeps being charged as scheduled, so the two cancel each other out."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Um crédito de %2$@ será adicionado à sua próxima fatura, cobrindo a %1$d parcela que ainda será cobrada.\n\nA parcela continua sendo cobrada normalmente, então as duas se anulam."
+          }
+        }
+      }
+    },
+    "cancellation.confirm.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel this purchase?"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar esta compra?"
+          }
+        }
+      }
+    },
+    "cancellation.details.note": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "These installments keep being charged on their original statements. This credit covers their total, so the net effect over time is zero."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estas parcelas continuam sendo cobradas nas faturas originais. Este crédito cobre o total delas, então o efeito final é zero."
+          }
+        }
+      }
+    },
+    "cancellation.details.refunded.header": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installments refunded"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Parcelas estornadas"
+          }
+        }
+      }
+    },
+    "cancellation.entry.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel purchase"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar compra"
+          }
+        }
+      }
+    },
+    "cancellation.error.generic": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The purchase could not be cancelled. Nothing was changed."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Não foi possível cancelar a compra. Nada foi alterado."
+          }
+        }
+      }
+    },
+    "cancellation.transaction.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancellation refund — %@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estorno — %@"
+          }
+        }
+      }
+    },
+    "cancellation.undo.action": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Undo"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desfazer"
+          }
+        }
+      }
+    },
+    "cancellation.undo.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The credit will be removed and the purchase will no longer be marked as cancelled."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O crédito será removido e a compra deixará de ficar marcada como cancelada."
+          }
+        }
+      }
+    },
+    "cancellation.undo.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Undo cancellation"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desfazer cancelamento"
+          }
+        }
+      }
+    },
+    "earlyPayment.badge.settled": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paid early"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Antecipada"
+          }
+        }
+      }
+    },
+    "earlyPayment.button.continue": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continue"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continuar"
+          }
+        }
+      }
+    },
+    "earlyPayment.confirm.action": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirm"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirmar"
+          }
+        }
+      }
+    },
+    "earlyPayment.confirm.destination.standalone": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Will be recorded as a separate debit, outside the card."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Será registrado como um débito separado, fora do cartão."
+          }
+        }
+      }
+    },
+    "earlyPayment.confirm.destination.statement": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Will be added to the open statement of %@."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Será adicionado à fatura aberta do %@."
+          }
+        }
+      }
+    },
+    "earlyPayment.confirm.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$d installment(s), %2$@, on %3$@.\n\n%4$@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$d parcela(s), %2$@, em %3$@.\n\n%4$@"
+          }
+        }
+      }
+    },
+    "earlyPayment.confirm.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirm early payment"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirmar antecipação"
+          }
+        }
+      }
+    },
+    "earlyPayment.date.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Payment date"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Data do pagamento"
+          }
+        }
+      }
+    },
+    "earlyPayment.destination.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Charge to"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lançar em"
+          }
+        }
+      }
+    },
+    "earlyPayment.destination.openStatement": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Card's open statement"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fatura aberta do cartão"
+          }
+        }
+      }
+    },
+    "earlyPayment.destination.standalone": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Outside the card"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fora do cartão"
+          }
+        }
+      }
+    },
+    "earlyPayment.destination.standalone.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A separate debit on the chosen date"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Um débito separado na data escolhida"
+          }
+        }
+      }
+    },
+    "earlyPayment.details.included.header": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installments included"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Parcelas incluídas"
+          }
+        }
+      }
+    },
+    "earlyPayment.empty": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This series has no future installments left to pay early."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esta compra não tem mais parcelas futuras para antecipar."
+          }
+        }
+      }
+    },
+    "earlyPayment.entry.count.plural": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d available"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d disponíveis"
+          }
+        }
+      }
+    },
+    "earlyPayment.entry.count.singular": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d available"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d disponível"
+          }
+        }
+      }
+    },
+    "earlyPayment.entry.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pay installments early"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Antecipar parcelas"
+          }
+        }
+      }
+    },
+    "earlyPayment.error.generic": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The early payment could not be completed. Nothing was changed."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Não foi possível concluir a antecipação. Nada foi alterado."
+          }
+        }
+      }
+    },
+    "earlyPayment.footer.count.plural": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d installments selected"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d parcelas selecionadas"
+          }
+        }
+      }
+    },
+    "earlyPayment.footer.count.singular": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d installment selected"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d parcela selecionada"
+          }
+        }
+      }
+    },
+    "earlyPayment.footer.total": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Amount paid early"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Valor antecipado"
+          }
+        }
+      }
+    },
+    "earlyPayment.header.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pay installments early"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Antecipar parcelas"
+          }
+        }
+      }
+    },
+    "earlyPayment.installmentRow": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installment %d of %d (%@)"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Parcela %d de %d (%@)"
+          }
+        }
+      }
+    },
+    "earlyPayment.installments.header": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Future installments"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Parcelas futuras"
+          }
+        }
+      }
+    },
+    "earlyPayment.intro": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose the installments of “%@” you want to pay early. Each one you select stops counting toward its own month."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escolha as parcelas de “%@” que você quer antecipar. Cada parcela selecionada deixa de contar no mês dela."
+          }
+        }
+      }
+    },
+    "earlyPayment.label.remaining": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remaining"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restante"
+          }
+        }
+      }
+    },
+    "earlyPayment.payment.header": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Payment"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pagamento"
+          }
+        }
+      }
+    },
+    "earlyPayment.selectAll": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select all"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selecionar tudo"
+          }
+        }
+      }
+    },
+    "earlyPayment.transaction.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Early payment — %@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Antecipação — %@"
+          }
+        }
+      }
+    },
+    "earlyPayment.undo.action": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Undo"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desfazer"
+          }
+        }
+      }
+    },
+    "earlyPayment.undo.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The installments will go back to their original statements and this debit will be deleted."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "As parcelas voltarão para as faturas originais e este débito será excluído."
+          }
+        }
+      }
+    },
+    "earlyPayment.undo.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Undo early payment"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desfazer antecipação"
+          }
+        }
+      }
+    },
+    "allocationTags.categories.inOtherTag": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "In %@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Em %@"
+          }
+        }
+      }
+    },
+    "allocationTags.categories.move.button": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Move"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mover"
+          }
+        }
+      }
+    },
+    "allocationTags.categories.move.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ is currently in %2$@. It can belong to one tag at a time."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ está em %2$@. Ela pode pertencer a apenas uma etiqueta por vez."
+          }
+        }
+      }
+    },
+    "allocationTags.categories.move.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Move category?"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mover categoria?"
+          }
+        }
+      }
+    },
+    "allocationTags.categories.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pick the categories this tag covers"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escolha as categorias que esta etiqueta cobre"
+          }
+        }
+      }
+    },
+    "allocationTags.categories.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Categories"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Categorias"
+          }
+        }
+      }
+    },
+    "allocationTags.create.button": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Create"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Criar"
+          }
+        }
+      }
+    },
+    "allocationTags.create.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Name this group of categories"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dê um nome a este grupo de categorias"
+          }
+        }
+      }
+    },
+    "allocationTags.create.namePlaceholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Essentials"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Essenciais"
+          }
+        }
+      }
+    },
+    "allocationTags.create.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New tag"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nova etiqueta"
+          }
+        }
+      }
+    },
+    "allocationTags.delete.confirm": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Excluir"
+          }
+        }
+      }
+    },
+    "allocationTags.delete.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Only the grouping is removed. Your allocations and transactions are untouched."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apenas o agrupamento é removido. Suas alocações e transações não são afetadas."
+          }
+        }
+      }
+    },
+    "allocationTags.delete.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete tag?"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Excluir etiqueta?"
+          }
+        }
+      }
+    },
+    "allocationTags.edit.categories.row": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Categories"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Categorias"
+          }
+        }
+      }
+    },
+    "allocationTags.edit.delete.button": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete tag"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Excluir etiqueta"
+          }
+        }
+      }
+    },
+    "allocationTags.edit.error.name.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Give this tag a name so you can recognise it."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dê um nome a esta etiqueta para poder reconhecê-la."
+          }
+        }
+      }
+    },
+    "allocationTags.edit.error.name.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Name required"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nome obrigatório"
+          }
+        }
+      }
+    },
+    "allocationTags.edit.input.color": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Color"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cor"
+          }
+        }
+      }
+    },
+    "allocationTags.edit.input.icon": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Icon"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ícone"
+          }
+        }
+      }
+    },
+    "allocationTags.edit.input.name": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Name"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nome"
+          }
+        }
+      }
+    },
+    "allocationTags.edit.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edit tag"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Editar etiqueta"
+          }
+        }
+      }
+    },
+    "allocationTags.emptyState.description": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No tags yet. Create one to group your categories."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhuma etiqueta ainda. Crie uma para agrupar suas categorias."
+          }
+        }
+      }
+    },
+    "allocationTags.row.categoryCount": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d categories"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d categorias"
+          }
+        }
+      }
+    },
+    "allocationTags.row.categoryCount.one": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 category"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 categoria"
+          }
+        }
+      }
+    },
+    "allocationTags.row.noCategories": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No categories yet"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhuma categoria ainda"
+          }
+        }
+      }
+    },
+    "allocationTags.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group categories to see what a set costs"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agrupe categorias para ver quanto um conjunto custa"
+          }
+        }
+      }
+    },
+    "allocationTags.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allocation tags"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Etiquetas de alocação"
+          }
+        }
+      }
+    },
+    "budget.allocations.emptyState.filtered": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No allocations in this tag"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhuma alocação nesta etiqueta"
+          }
+        }
+      }
+    },
+    "budget.projection.saved.format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ saved"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ economizado"
+          }
+        }
+      }
+    },
+    "budget.tag.shareOfBudget": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d%% of budget"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d%% do orçamento"
+          }
+        }
+      }
+    },
+    "budget.tags.strip.clear": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear filter"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limpar filtro"
+          }
+        }
+      }
+    },
+    "budget.tags.strip.untagged": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Untagged"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sem etiqueta"
+          }
+        }
+      }
+    },
+    "budgets.tags.manage": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tags"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Etiquetas"
           }
         }
       }

--- a/Finova/Resources/Localizable.xcstrings
+++ b/Finova/Resources/Localizable.xcstrings
@@ -192,6 +192,23 @@
         }
       }
     },
+    "addCreditCard.input.creditLimit": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Credit Limit (optional)"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limite de Crédito (opcional)"
+          }
+        }
+      }
+    },
     "addCreditCard.input.defaultCard": {
       "extractionState": "manual",
       "localizations": {
@@ -222,23 +239,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Pré-selecionar este cartão ao adicionar transações"
-          }
-        }
-      }
-    },
-    "addCreditCard.input.creditLimit": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Credit Limit (optional)"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Limite de Crédito (opcional)"
           }
         }
       }
@@ -617,6 +617,23 @@
         }
       }
     },
+    "addTransactionModal.paymentMethod.createCard": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Create Card"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Criar Cartão"
+          }
+        }
+      }
+    },
     "addTransactionModal.paymentMethod.creditCard": {
       "extractionState": "manual",
       "localizations": {
@@ -681,23 +698,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Toque para adicionar um cartão"
-          }
-        }
-      }
-    },
-    "addTransactionModal.paymentMethod.createCard": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Create Card"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Criar Cartão"
           }
         }
       }
@@ -2011,6 +2011,465 @@
         }
       }
     },
+    "allocationTags.categories.inOtherTag": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "In %@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Em %@"
+          }
+        }
+      }
+    },
+    "allocationTags.categories.move.button": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Move"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mover"
+          }
+        }
+      }
+    },
+    "allocationTags.categories.move.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ is currently in %2$@. It can belong to one tag at a time."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ está em %2$@. Ela pode pertencer a apenas uma etiqueta por vez."
+          }
+        }
+      }
+    },
+    "allocationTags.categories.move.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Move category?"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mover categoria?"
+          }
+        }
+      }
+    },
+    "allocationTags.categories.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pick the categories this tag covers"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escolha as categorias que esta etiqueta cobre"
+          }
+        }
+      }
+    },
+    "allocationTags.categories.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Categories"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Categorias"
+          }
+        }
+      }
+    },
+    "allocationTags.create.button": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Create"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Criar"
+          }
+        }
+      }
+    },
+    "allocationTags.create.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Name this group of categories"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dê um nome a este grupo de categorias"
+          }
+        }
+      }
+    },
+    "allocationTags.create.namePlaceholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Essentials"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Essenciais"
+          }
+        }
+      }
+    },
+    "allocationTags.create.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New tag"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nova etiqueta"
+          }
+        }
+      }
+    },
+    "allocationTags.delete.confirm": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Excluir"
+          }
+        }
+      }
+    },
+    "allocationTags.delete.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Only the grouping is removed. Your allocations and transactions are untouched."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apenas o agrupamento é removido. Suas alocações e transações não são afetadas."
+          }
+        }
+      }
+    },
+    "allocationTags.delete.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete tag?"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Excluir etiqueta?"
+          }
+        }
+      }
+    },
+    "allocationTags.edit.categories.row": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Categories"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Categorias"
+          }
+        }
+      }
+    },
+    "allocationTags.edit.delete.button": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete tag"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Excluir etiqueta"
+          }
+        }
+      }
+    },
+    "allocationTags.edit.error.name.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Give this tag a name so you can recognise it."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dê um nome a esta etiqueta para poder reconhecê-la."
+          }
+        }
+      }
+    },
+    "allocationTags.edit.error.name.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Name required"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nome obrigatório"
+          }
+        }
+      }
+    },
+    "allocationTags.edit.input.color": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Color"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cor"
+          }
+        }
+      }
+    },
+    "allocationTags.edit.input.icon": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Icon"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ícone"
+          }
+        }
+      }
+    },
+    "allocationTags.edit.input.name": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Name"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nome"
+          }
+        }
+      }
+    },
+    "allocationTags.edit.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edit tag"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Editar etiqueta"
+          }
+        }
+      }
+    },
+    "allocationTags.emptyState.description": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No tags yet. Create one to group your categories."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhuma etiqueta ainda. Crie uma para agrupar suas categorias."
+          }
+        }
+      }
+    },
+    "allocationTags.row.categoryCount": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d categories"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d categorias"
+          }
+        }
+      }
+    },
+    "allocationTags.row.categoryCount.one": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 category"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 categoria"
+          }
+        }
+      }
+    },
+    "allocationTags.row.noCategories": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No categories yet"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhuma categoria ainda"
+          }
+        }
+      }
+    },
+    "allocationTags.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group categories to see what a set costs"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agrupe categorias para ver quanto um conjunto custa"
+          }
+        }
+      }
+    },
+    "allocationTags.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allocation tags"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Etiquetas de alocação"
+          }
+        }
+      }
+    },
     "auth.dialog.accountFound.message": {
       "extractionState": "manual",
       "localizations": {
@@ -2487,23 +2946,6 @@
         }
       }
     },
-    "biometrics.generic.name": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Biometrics"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Biometria"
-          }
-        }
-      }
-    },
     "biometric.error.authenticationFailed": {
       "extractionState": "manual",
       "localizations": {
@@ -2555,6 +2997,23 @@
         }
       }
     },
+    "biometrics.generic.name": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Biometrics"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Biometria"
+          }
+        }
+      }
+    },
     "budget.allocated.label": {
       "extractionState": "manual",
       "localizations": {
@@ -2602,6 +3061,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "Nenhuma alocação de orçamento para este mês"
+          }
+        }
+      }
+    },
+    "budget.allocations.emptyState.filtered": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No allocations in this tag"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhuma alocação nesta etiqueta"
           }
         }
       }
@@ -2810,6 +3286,23 @@
         }
       }
     },
+    "budget.projection.saved.format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ saved"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ economizado"
+          }
+        }
+      }
+    },
     "budget.projection.saved.label": {
       "extractionState": "manual",
       "localizations": {
@@ -2857,6 +3350,57 @@
           "stringUnit": {
             "state": "translated",
             "value": "acima"
+          }
+        }
+      }
+    },
+    "budget.tag.shareOfBudget": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d%% of budget"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d%% do orçamento"
+          }
+        }
+      }
+    },
+    "budget.tags.strip.clear": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear filter"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limpar filtro"
+          }
+        }
+      }
+    },
+    "budget.tags.strip.untagged": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Untagged"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sem etiqueta"
           }
         }
       }
@@ -3116,6 +3660,227 @@
         }
       }
     },
+    "budgets.tags.manage": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tags"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Etiquetas"
+          }
+        }
+      }
+    },
+    "cancellation.confirm.action": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel purchase"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar compra"
+          }
+        }
+      }
+    },
+    "cancellation.confirm.message.plural": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A credit of %2$@ will be added to your next statement, covering the %1$d installments still to be billed.\n\nThose installments keep being charged as scheduled, so the two cancel each other out."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Um crédito de %2$@ será adicionado à sua próxima fatura, cobrindo as %1$d parcelas que ainda serão cobradas.\n\nEssas parcelas continuam sendo cobradas normalmente, então as duas se anulam."
+          }
+        }
+      }
+    },
+    "cancellation.confirm.message.singular": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A credit of %2$@ will be added to your next statement, covering the %1$d installment still to be billed.\n\nThe installment keeps being charged as scheduled, so the two cancel each other out."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Um crédito de %2$@ será adicionado à sua próxima fatura, cobrindo a %1$d parcela que ainda será cobrada.\n\nA parcela continua sendo cobrada normalmente, então as duas se anulam."
+          }
+        }
+      }
+    },
+    "cancellation.confirm.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel this purchase?"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar esta compra?"
+          }
+        }
+      }
+    },
+    "cancellation.details.note": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "These installments keep being charged on their original statements. This credit covers their total, so the net effect over time is zero."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estas parcelas continuam sendo cobradas nas faturas originais. Este crédito cobre o total delas, então o efeito final é zero."
+          }
+        }
+      }
+    },
+    "cancellation.details.refunded.header": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installments refunded"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Parcelas estornadas"
+          }
+        }
+      }
+    },
+    "cancellation.entry.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel purchase"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar compra"
+          }
+        }
+      }
+    },
+    "cancellation.error.generic": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The purchase could not be cancelled. Nothing was changed."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Não foi possível cancelar a compra. Nada foi alterado."
+          }
+        }
+      }
+    },
+    "cancellation.transaction.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancellation refund — %@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estorno — %@"
+          }
+        }
+      }
+    },
+    "cancellation.undo.action": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Undo"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desfazer"
+          }
+        }
+      }
+    },
+    "cancellation.undo.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The credit will be removed and the purchase will no longer be marked as cancelled."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O crédito será removido e a compra deixará de ficar marcada como cancelada."
+          }
+        }
+      }
+    },
+    "cancellation.undo.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Undo cancellation"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desfazer cancelamento"
+          }
+        }
+      }
+    },
     "cardBrand.amex": {
       "extractionState": "manual",
       "localizations": {
@@ -3235,23 +4000,6 @@
         }
       }
     },
-    "category.creditCard": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Credit Card"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cartão de Crédito"
-          }
-        }
-      }
-    },
     "category.clothing": {
       "extractionState": "manual",
       "localizations": {
@@ -3299,6 +4047,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "Crédito"
+          }
+        }
+      }
+    },
+    "category.creditCard": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Credit Card"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cartão de Crédito"
           }
         }
       }
@@ -3796,23 +4561,6 @@
         }
       }
     },
-    "creditCards.cell.default": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "DEFAULT"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "PADRÃO"
-          }
-        }
-      }
-    },
     "creditCards.cell.currentStatement": {
       "extractionState": "manual",
       "localizations": {
@@ -3826,6 +4574,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "Atual: %@"
+          }
+        }
+      }
+    },
+    "creditCards.cell.default": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DEFAULT"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PADRÃO"
           }
         }
       }
@@ -4030,6 +4795,550 @@
           "stringUnit": {
             "state": "translated",
             "value": "Tem certeza?"
+          }
+        }
+      }
+    },
+    "earlyPayment.badge.settled": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paid early"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Antecipada"
+          }
+        }
+      }
+    },
+    "earlyPayment.button.continue": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continue"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continuar"
+          }
+        }
+      }
+    },
+    "earlyPayment.confirm.action": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirm"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirmar"
+          }
+        }
+      }
+    },
+    "earlyPayment.confirm.destination.standalone": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Will be recorded as a separate debit, outside the card."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Será registrado como um débito separado, fora do cartão."
+          }
+        }
+      }
+    },
+    "earlyPayment.confirm.destination.statement": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Will be added to the open statement of %@."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Será adicionado à fatura aberta do %@."
+          }
+        }
+      }
+    },
+    "earlyPayment.confirm.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$d installment(s), %2$@, on %3$@.\n\n%4$@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$d parcela(s), %2$@, em %3$@.\n\n%4$@"
+          }
+        }
+      }
+    },
+    "earlyPayment.confirm.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirm early payment"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirmar antecipação"
+          }
+        }
+      }
+    },
+    "earlyPayment.date.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Payment date"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Data do pagamento"
+          }
+        }
+      }
+    },
+    "earlyPayment.destination.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Charge to"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lançar em"
+          }
+        }
+      }
+    },
+    "earlyPayment.destination.openStatement": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Card's open statement"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fatura aberta do cartão"
+          }
+        }
+      }
+    },
+    "earlyPayment.destination.standalone": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Outside the card"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fora do cartão"
+          }
+        }
+      }
+    },
+    "earlyPayment.destination.standalone.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A separate debit on the chosen date"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Um débito separado na data escolhida"
+          }
+        }
+      }
+    },
+    "earlyPayment.details.included.header": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installments included"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Parcelas incluídas"
+          }
+        }
+      }
+    },
+    "earlyPayment.empty": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This series has no future installments left to pay early."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esta compra não tem mais parcelas futuras para antecipar."
+          }
+        }
+      }
+    },
+    "earlyPayment.entry.count.plural": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d available"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d disponíveis"
+          }
+        }
+      }
+    },
+    "earlyPayment.entry.count.singular": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d available"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d disponível"
+          }
+        }
+      }
+    },
+    "earlyPayment.entry.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pay installments early"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Antecipar parcelas"
+          }
+        }
+      }
+    },
+    "earlyPayment.error.generic": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The early payment could not be completed. Nothing was changed."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Não foi possível concluir a antecipação. Nada foi alterado."
+          }
+        }
+      }
+    },
+    "earlyPayment.footer.count.plural": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d installments selected"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d parcelas selecionadas"
+          }
+        }
+      }
+    },
+    "earlyPayment.footer.count.singular": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d installment selected"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d parcela selecionada"
+          }
+        }
+      }
+    },
+    "earlyPayment.footer.total": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Amount paid early"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Valor antecipado"
+          }
+        }
+      }
+    },
+    "earlyPayment.header.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pay installments early"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Antecipar parcelas"
+          }
+        }
+      }
+    },
+    "earlyPayment.installmentRow": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installment %d of %d (%@)"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Parcela %d de %d (%@)"
+          }
+        }
+      }
+    },
+    "earlyPayment.installments.header": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Future installments"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Parcelas futuras"
+          }
+        }
+      }
+    },
+    "earlyPayment.intro": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose the installments of “%@” you want to pay early. Each one you select stops counting toward its own month."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escolha as parcelas de “%@” que você quer antecipar. Cada parcela selecionada deixa de contar no mês dela."
+          }
+        }
+      }
+    },
+    "earlyPayment.label.remaining": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remaining"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restante"
+          }
+        }
+      }
+    },
+    "earlyPayment.payment.header": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Payment"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pagamento"
+          }
+        }
+      }
+    },
+    "earlyPayment.selectAll": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select all"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selecionar tudo"
+          }
+        }
+      }
+    },
+    "earlyPayment.transaction.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Early payment — %@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Antecipação — %@"
+          }
+        }
+      }
+    },
+    "earlyPayment.undo.action": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Undo"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desfazer"
+          }
+        }
+      }
+    },
+    "earlyPayment.undo.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The installments will go back to their original statements and this debit will be deleted."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "As parcelas voltarão para as faturas originais e este débito será excluído."
+          }
+        }
+      }
+    },
+    "earlyPayment.undo.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Undo early payment"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desfazer antecipação"
           }
         }
       }
@@ -5989,6 +7298,74 @@
         }
       }
     },
+    "notification.statement.dueSoon.body": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your %@ statement of %@ is due in 3 days"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sua fatura do %@ de %@ vence em 3 dias"
+          }
+        }
+      }
+    },
+    "notification.statement.dueSoon.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Statement Due Soon"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fatura Vencendo em Breve"
+          }
+        }
+      }
+    },
+    "notification.statement.paymentDue.body": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your %@ statement of %@ is due today. Don't forget to pay!"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sua fatura do %@ de %@ vence hoje. Não esqueça de pagar!"
+          }
+        }
+      }
+    },
+    "notification.statement.paymentDue.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Payment Due Today"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pagamento Vence Hoje"
+          }
+        }
+      }
+    },
     "notification.test.body": {
       "extractionState": "manual",
       "localizations": {
@@ -6121,74 +7498,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Crédito agendado"
-          }
-        }
-      }
-    },
-    "notification.statement.dueSoon.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Statement Due Soon"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fatura Vencendo em Breve"
-          }
-        }
-      }
-    },
-    "notification.statement.dueSoon.body": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your %@ statement of %@ is due in 3 days"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sua fatura do %@ de %@ vence em 3 dias"
-          }
-        }
-      }
-    },
-    "notification.statement.paymentDue.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Payment Due Today"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pagamento Vence Hoje"
-          }
-        }
-      }
-    },
-    "notification.statement.paymentDue.body": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your %@ statement of %@ is due today. Don't forget to pay!"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sua fatura do %@ de %@ vence hoje. Não esqueça de pagar!"
           }
         }
       }
@@ -6346,6 +7655,40 @@
         }
       }
     },
+    "notificationSettings.creditCardStatement.description": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reminders for upcoming statement due dates"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lembretes para datas de vencimento de faturas"
+          }
+        }
+      }
+    },
+    "notificationSettings.creditCardStatement.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Credit Card Statements"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Faturas de Cartão"
+          }
+        }
+      }
+    },
     "notificationSettings.disableAll.description": {
       "extractionState": "manual",
       "localizations": {
@@ -6427,40 +7770,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Aviso de Saldo Negativo"
-          }
-        }
-      }
-    },
-    "notificationSettings.creditCardStatement.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Credit Card Statements"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Faturas de Cartão"
-          }
-        }
-      }
-    },
-    "notificationSettings.creditCardStatement.description": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reminders for upcoming statement due dates"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lembretes para datas de vencimento de faturas"
           }
         }
       }
@@ -6652,6 +7961,23 @@
         }
       }
     },
+    "profile.creditCards.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Credit Cards"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cartões de Crédito"
+          }
+        }
+      }
+    },
     "profile.header.title": {
       "extractionState": "manual",
       "localizations": {
@@ -6665,6 +7991,74 @@
           "stringUnit": {
             "state": "translated",
             "value": "Minha Conta"
+          }
+        }
+      }
+    },
+    "profile.logout.confirm.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Are you sure you want to logout?"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tem certeza que deseja sair?"
+          }
+        }
+      }
+    },
+    "profile.logout.confirm.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Logout"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sair"
+          }
+        }
+      }
+    },
+    "profile.logout.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Logout"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sair"
+          }
+        }
+      }
+    },
+    "profile.section.account": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Account"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conta"
           }
         }
       }
@@ -6703,40 +8097,6 @@
         }
       }
     },
-    "profile.section.account": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Account"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Conta"
-          }
-        }
-      }
-    },
-    "profile.creditCards.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Credit Cards"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cartões de Crédito"
-          }
-        }
-      }
-    },
     "profile.settings.title": {
       "extractionState": "manual",
       "localizations": {
@@ -6750,57 +8110,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Configurações"
-          }
-        }
-      }
-    },
-    "profile.logout.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Logout"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sair"
-          }
-        }
-      }
-    },
-    "profile.logout.confirm.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Logout"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sair"
-          }
-        }
-      }
-    },
-    "profile.logout.confirm.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Are you sure you want to logout?"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tem certeza que deseja sair?"
           }
         }
       }
@@ -7604,23 +8913,6 @@
         }
       }
     },
-    "statementDetails.dueDate": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Due Date"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Data de Vencimento"
-          }
-        }
-      }
-    },
     "statementDetails.card": {
       "extractionState": "manual",
       "localizations": {
@@ -7651,6 +8943,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "Data de Fechamento"
+          }
+        }
+      }
+    },
+    "statementDetails.dueDate": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Due Date"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Data de Vencimento"
           }
         }
       }
@@ -8182,6 +9491,23 @@
         }
       }
     },
+    "transactionDetails.label.paymentMethod": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Payment method"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Método de pagamento"
+          }
+        }
+      }
+    },
     "transactionDetails.label.totalValue": {
       "extractionState": "manual",
       "localizations": {
@@ -8212,23 +9538,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Tipo"
-          }
-        }
-      }
-    },
-    "transactionDetails.label.paymentMethod": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Payment method"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Método de pagamento"
           }
         }
       }
@@ -8518,754 +9827,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Sim"
-          }
-        }
-      }
-    },
-    "cancellation.confirm.action": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancel purchase"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancelar compra"
-          }
-        }
-      }
-    },
-    "cancellation.confirm.message.plural": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A credit of %2$@ will be added to your next statement, covering the %1$d installments still to be billed.\n\nThose installments keep being charged as scheduled, so the two cancel each other out."
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Um crédito de %2$@ será adicionado à sua próxima fatura, cobrindo as %1$d parcelas que ainda serão cobradas.\n\nEssas parcelas continuam sendo cobradas normalmente, então as duas se anulam."
-          }
-        }
-      }
-    },
-    "cancellation.confirm.message.singular": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A credit of %2$@ will be added to your next statement, covering the %1$d installment still to be billed.\n\nThe installment keeps being charged as scheduled, so the two cancel each other out."
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Um crédito de %2$@ será adicionado à sua próxima fatura, cobrindo a %1$d parcela que ainda será cobrada.\n\nA parcela continua sendo cobrada normalmente, então as duas se anulam."
-          }
-        }
-      }
-    },
-    "cancellation.confirm.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancel this purchase?"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancelar esta compra?"
-          }
-        }
-      }
-    },
-    "cancellation.details.note": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "These installments keep being charged on their original statements. This credit covers their total, so the net effect over time is zero."
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Estas parcelas continuam sendo cobradas nas faturas originais. Este crédito cobre o total delas, então o efeito final é zero."
-          }
-        }
-      }
-    },
-    "cancellation.details.refunded.header": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Installments refunded"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Parcelas estornadas"
-          }
-        }
-      }
-    },
-    "cancellation.entry.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancel purchase"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancelar compra"
-          }
-        }
-      }
-    },
-    "cancellation.error.generic": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The purchase could not be cancelled. Nothing was changed."
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Não foi possível cancelar a compra. Nada foi alterado."
-          }
-        }
-      }
-    },
-    "cancellation.transaction.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancellation refund — %@"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Estorno — %@"
-          }
-        }
-      }
-    },
-    "cancellation.undo.action": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Undo"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Desfazer"
-          }
-        }
-      }
-    },
-    "cancellation.undo.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The credit will be removed and the purchase will no longer be marked as cancelled."
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "O crédito será removido e a compra deixará de ficar marcada como cancelada."
-          }
-        }
-      }
-    },
-    "cancellation.undo.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Undo cancellation"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Desfazer cancelamento"
-          }
-        }
-      }
-    },
-    "earlyPayment.badge.settled": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Paid early"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Antecipada"
-          }
-        }
-      }
-    },
-    "earlyPayment.button.continue": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Continue"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Continuar"
-          }
-        }
-      }
-    },
-    "earlyPayment.confirm.action": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Confirm"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Confirmar"
-          }
-        }
-      }
-    },
-    "earlyPayment.confirm.destination.standalone": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Will be recorded as a separate debit, outside the card."
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Será registrado como um débito separado, fora do cartão."
-          }
-        }
-      }
-    },
-    "earlyPayment.confirm.destination.statement": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Will be added to the open statement of %@."
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Será adicionado à fatura aberta do %@."
-          }
-        }
-      }
-    },
-    "earlyPayment.confirm.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$d installment(s), %2$@, on %3$@.\n\n%4$@"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$d parcela(s), %2$@, em %3$@.\n\n%4$@"
-          }
-        }
-      }
-    },
-    "earlyPayment.confirm.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Confirm early payment"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Confirmar antecipação"
-          }
-        }
-      }
-    },
-    "earlyPayment.date.label": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Payment date"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Data do pagamento"
-          }
-        }
-      }
-    },
-    "earlyPayment.destination.label": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Charge to"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lançar em"
-          }
-        }
-      }
-    },
-    "earlyPayment.destination.openStatement": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Card's open statement"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fatura aberta do cartão"
-          }
-        }
-      }
-    },
-    "earlyPayment.destination.standalone": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Outside the card"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fora do cartão"
-          }
-        }
-      }
-    },
-    "earlyPayment.destination.standalone.subtitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A separate debit on the chosen date"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Um débito separado na data escolhida"
-          }
-        }
-      }
-    },
-    "earlyPayment.details.included.header": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Installments included"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Parcelas incluídas"
-          }
-        }
-      }
-    },
-    "earlyPayment.empty": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This series has no future installments left to pay early."
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Esta compra não tem mais parcelas futuras para antecipar."
-          }
-        }
-      }
-    },
-    "earlyPayment.entry.count.plural": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%d available"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%d disponíveis"
-          }
-        }
-      }
-    },
-    "earlyPayment.entry.count.singular": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%d available"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%d disponível"
-          }
-        }
-      }
-    },
-    "earlyPayment.entry.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pay installments early"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Antecipar parcelas"
-          }
-        }
-      }
-    },
-    "earlyPayment.error.generic": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The early payment could not be completed. Nothing was changed."
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Não foi possível concluir a antecipação. Nada foi alterado."
-          }
-        }
-      }
-    },
-    "earlyPayment.footer.count.plural": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%d installments selected"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%d parcelas selecionadas"
-          }
-        }
-      }
-    },
-    "earlyPayment.footer.count.singular": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%d installment selected"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%d parcela selecionada"
-          }
-        }
-      }
-    },
-    "earlyPayment.footer.total": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Amount paid early"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Valor antecipado"
-          }
-        }
-      }
-    },
-    "earlyPayment.header.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pay installments early"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Antecipar parcelas"
-          }
-        }
-      }
-    },
-    "earlyPayment.installmentRow": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Installment %d of %d (%@)"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Parcela %d de %d (%@)"
-          }
-        }
-      }
-    },
-    "earlyPayment.installments.header": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Future installments"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Parcelas futuras"
-          }
-        }
-      }
-    },
-    "earlyPayment.intro": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Choose the installments of “%@” you want to pay early. Each one you select stops counting toward its own month."
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Escolha as parcelas de “%@” que você quer antecipar. Cada parcela selecionada deixa de contar no mês dela."
-          }
-        }
-      }
-    },
-    "earlyPayment.label.remaining": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Remaining"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Restante"
-          }
-        }
-      }
-    },
-    "earlyPayment.payment.header": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Payment"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pagamento"
-          }
-        }
-      }
-    },
-    "earlyPayment.selectAll": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Select all"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Selecionar tudo"
-          }
-        }
-      }
-    },
-    "earlyPayment.transaction.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Early payment — %@"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Antecipação — %@"
-          }
-        }
-      }
-    },
-    "earlyPayment.undo.action": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Undo"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Desfazer"
-          }
-        }
-      }
-    },
-    "earlyPayment.undo.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The installments will go back to their original statements and this debit will be deleted."
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "As parcelas voltarão para as faturas originais e este débito será excluído."
-          }
-        }
-      }
-    },
-    "earlyPayment.undo.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Undo early payment"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Desfazer antecipação"
           }
         }
       }

--- a/Finova/Sources/Core/Extensions/Notification+Ext.swift
+++ b/Finova/Sources/Core/Extensions/Notification+Ext.swift
@@ -13,4 +13,5 @@ extension Notification.Name {
   static let navigateToTransactionDetails = Notification.Name("navigateToTransactionDetails")
   static let currencyDidChange = Notification.Name("currencyDidChange")
   static let navigateToStatementDetails = Notification.Name("navigateToStatementDetails")
+  static let allocationTagsChanged = Notification.Name("allocationTagsChanged")
 }

--- a/Finova/Sources/Core/Factories/ViewControllersFactory/ViewControllersFactory.swift
+++ b/Finova/Sources/Core/Factories/ViewControllersFactory/ViewControllersFactory.swift
@@ -172,6 +172,27 @@ final class ViewControllersFactory: ViewControllersFactoryProtocol {
         return viewController
     }
 
+    func makeAllocationTagsViewController(flowDelegate: AllocationTagsFlowDelegate) -> AllocationTagsViewController {
+        let contentView = AllocationTagsView()
+        let viewModel = AllocationTagsViewModel()
+        let viewController = AllocationTagsViewController(
+            contentView: contentView, viewModel: viewModel, flowDelegate: flowDelegate)
+        return viewController
+    }
+
+    func makeAllocationTagEditViewController(flowDelegate: AllocationTagEditFlowDelegate, tag: AllocationTag) -> AllocationTagEditViewController {
+        let contentView = AllocationTagEditView()
+        let viewController = AllocationTagEditViewController(
+            contentView: contentView, tag: tag, flowDelegate: flowDelegate)
+        return viewController
+    }
+
+    func makeAllocationTagCategoriesViewController(flowDelegate: AllocationTagCategoriesFlowDelegate, tag: AllocationTag) -> AllocationTagCategoriesViewController {
+        let contentView = AllocationTagCategoriesView()
+        let viewController = AllocationTagCategoriesViewController(
+            contentView: contentView, tag: tag, flowDelegate: flowDelegate)
+        return viewController
+    }
     // MARK: - Budget Allocation Details
 
     static func makeBudgetAllocationDetailsViewController(

--- a/Finova/Sources/Core/Factories/ViewControllersFactory/ViewControllersFactoryProtocol.swift
+++ b/Finova/Sources/Core/Factories/ViewControllersFactory/ViewControllersFactoryProtocol.swift
@@ -40,4 +40,7 @@ protocol ViewControllersFactoryProtocol: AnyObject {
   func makeCreditCardsViewController(flowDelegate: CreditCardsFlowDelegate) -> CreditCardsViewController
   func makeAddCreditCardViewController(flowDelegate: AddCreditCardFlowDelegate, cardToEdit: CreditCard?) -> AddCreditCardViewController
   func makeStatementDetailsViewController(flowDelegate: StatementDetailsFlowDelegate, statement: CreditCardStatement, card: CreditCard) -> StatementDetailsViewController
+  func makeAllocationTagsViewController(flowDelegate: AllocationTagsFlowDelegate) -> AllocationTagsViewController
+  func makeAllocationTagEditViewController(flowDelegate: AllocationTagEditFlowDelegate, tag: AllocationTag) -> AllocationTagEditViewController
+  func makeAllocationTagCategoriesViewController(flowDelegate: AllocationTagCategoriesFlowDelegate, tag: AllocationTag) -> AllocationTagCategoriesViewController
 }

--- a/Finova/Sources/Core/Models/AllocationBalanceProjection.swift
+++ b/Finova/Sources/Core/Models/AllocationBalanceProjection.swift
@@ -141,21 +141,35 @@ struct AllocationBalanceProjection: Equatable {
     /// How far the allocations exceed the balance, or zero when they don't.
     var shortfall: Int { isOverCommitted ? abs(projected) : 0 }
 
-    /// Normalised widths for the two-segment bar: of the money actually spent, how much stayed
-    /// inside its allocation against how much broke out of it. Sums to 1, or is all-zero before
-    /// anything has been spent.
+    /// Normalised widths for the three-segment bar, comparing the block's three quantities against each
+    /// other. Sums to 1 whenever any of them is non-zero, and is all-zero otherwise so the bare track
+    /// shows through.
     ///
-    /// Tense-independent, and deliberately built from *spent* money rather than from `totalSaved`.
-    /// An open month cannot have saved anything yet - an unspent allocation is money the user plans
-    /// to spend, so counting it as kept would show a figure that erodes as the month fills in.
-    /// Plan adherence is true at every point in the month, and stays true once it closes.
-    var barShares: (withinPlan: CGFloat, beyondPlan: CGFloat) {
-        let total = usedWithinAllocations + overspent
-        guard total > 0 else { return (0, 0) }
+    /// - `projected`: what the balance is left with once the plan plays out. **Not** the saved amount -
+    ///   savings have already come out of it - which is why it takes the outgoing colour and not green.
+    /// - `saved`: `totalSaved`, money still sitting in the account: budget earmarked but not spent, plus
+    ///   the cap never earmarked at all.
+    /// - `overspent`: what broke out of the plan - category overruns plus spending with no plan behind it.
+    ///
+    /// Two earlier versions of this bar got the question wrong, so both are worth naming. It first
+    /// plotted plan *adherence* - of money spent, how much stayed inside its allocation - which came out
+    /// almost entirely green on any well-behaved month and so read as "all of this is saved". It then
+    /// plotted `projected` in green against the outgoing remainder, which put the biggest slice in the
+    /// colour meaning "saved" while the actual saved figure went unshown.
+    ///
+    /// A comparison, not a partition: `projected` and `saved` both derive from `unspentAllocations`, so
+    /// they do not add up to `base` and are not meant to.
+    var barShares: (projected: CGFloat, saved: CGFloat, overspent: CGFloat) {
+        // A negative projection has no width. The shortfall is named in the block's caption instead.
+        let survives = max(0, projected)
+        let total = survives + totalSaved + overspent
+        guard total > 0 else { return (0, 0, 0) }
+
         let divisor = CGFloat(total)
         return (
-            withinPlan: CGFloat(usedWithinAllocations) / divisor,
-            beyondPlan: CGFloat(overspent) / divisor
+            projected: CGFloat(survives) / divisor,
+            saved: CGFloat(totalSaved) / divisor,
+            overspent: CGFloat(overspent) / divisor
         )
     }
 }

--- a/Finova/Sources/Core/Models/AllocationTag.swift
+++ b/Finova/Sources/Core/Models/AllocationTag.swift
@@ -1,0 +1,162 @@
+//
+//  AllocationTag.swift
+//  Finova
+//
+//  Created by Arthur Rios on 04/08/26.
+//
+
+import UIKit
+
+// MARK: - Tag
+
+/// A user-created grouping of spending categories - "Essentials", "Wealth" - so the budget card can
+/// report what a whole set of categories costs in a month.
+///
+/// A tag binds to *categories*, never to a single month's allocation. Rent is an essential in every
+/// month, so asking the question per allocation row would mean answering it twelve times a year. The
+/// mapping lives in `AllocationTagBook.categoryTagIds`; this type is only the tag's identity.
+struct AllocationTag: Codable, Equatable, Identifiable {
+
+    let id: String
+    var name: String
+    /// Index into `AllocationTagPalette.entries`. Stored rather than a hex string so the palette can
+    /// be retuned in one place and a corrupt value can be clamped instead of failing to parse.
+    var colorIndex: Int
+    /// A `lucide_icon*` asset name. `nil` means the default glyph, which is the documented default
+    /// rather than a magic string.
+    var iconAssetName: String?
+    var sortOrder: Int
+
+    init(
+        id: String = UUID().uuidString,
+        name: String,
+        colorIndex: Int,
+        iconAssetName: String? = nil,
+        sortOrder: Int
+    ) {
+        self.id = id
+        self.name = name
+        self.colorIndex = colorIndex
+        self.iconAssetName = iconAssetName
+        self.sortOrder = sortOrder
+    }
+
+    var color: AllocationTagPalette.Entry {
+        AllocationTagPalette.entry(at: colorIndex)
+    }
+
+    /// Resolved at read time, not stored: an asset can vanish between app versions, and a missing
+    /// image would otherwise render as a blank square.
+    var icon: Icon {
+        if let iconAssetName, UIImage(named: iconAssetName) != nil {
+            return .asset(iconAssetName)
+        }
+        return .systemSymbol(Self.defaultSymbolName)
+    }
+
+    /// There is no `lucide_iconTag` asset, and the card already mixes SF Symbols in for exactly this
+    /// kind of gap (`questionmark.circle` on the donut, `creditcard.fill` in the card header).
+    static let defaultSymbolName = "tag.fill"
+
+    enum Icon: Equatable {
+        case asset(String)
+        case systemSymbol(String)
+
+        var image: UIImage? {
+            switch self {
+            case .asset(let name):
+                return UIImage(named: name)?.withRenderingMode(.alwaysTemplate)
+            case .systemSymbol(let name):
+                return UIImage(systemName: name)
+            }
+        }
+    }
+}
+
+// MARK: - Book
+
+/// Everything the tag feature persists: the catalog and the category mapping, in one value.
+///
+/// One blob rather than two stores because the two halves are only ever read together and must never
+/// disagree - a map entry pointing at a deleted tag is the one corruption worth designing out.
+struct AllocationTagBook: Codable, Equatable {
+
+    /// Payload version. The storage *key* is versioned too; see `AllocationTagStore`.
+    var schemaVersion: Int
+    var tags: [AllocationTag]
+    /// `TransactionCategory.key` -> `AllocationTag.id`. One tag per category: exclusive tags
+    /// partition the plan, which is what lets the subtotals add up to the budget and the donut render
+    /// them as contiguous arcs.
+    var categoryTagIds: [String: String]
+    /// Unused in v1. Present from the start because a cloud-backed store needs a last-writer-wins
+    /// field, and adding one later would be a schema change.
+    var updatedAt: Date
+
+    static let currentSchemaVersion = 1
+
+    static let empty = AllocationTagBook(
+        schemaVersion: currentSchemaVersion,
+        tags: [],
+        categoryTagIds: [:],
+        updatedAt: .distantPast
+    )
+
+    var isEmpty: Bool { tags.isEmpty }
+
+    /// Tags in display order.
+    var orderedTags: [AllocationTag] {
+        tags.sorted { lhs, rhs in
+            lhs.sortOrder == rhs.sortOrder ? lhs.id < rhs.id : lhs.sortOrder < rhs.sortOrder
+        }
+    }
+
+    func tag(id: String) -> AllocationTag? {
+        tags.first { $0.id == id }
+    }
+
+    func tagId(forCategoryKey key: String) -> String? {
+        categoryTagIds[key]
+    }
+
+    func categoryKeys(forTagId tagId: String) -> [String] {
+        categoryTagIds.filter { $0.value == tagId }.keys.sorted()
+    }
+
+    /// Drops everything that cannot be true, so no reader downstream has to defend against it.
+    ///
+    /// Applied on every load, so it also repairs a book written by a buggy or interrupted earlier
+    /// version rather than only guarding fresh input.
+    func sanitized() -> AllocationTagBook {
+        let validCategoryKeys = Set(TransactionCategory.allCases.map { $0.key })
+
+        var seenIds = Set<String>()
+        var cleanTags: [AllocationTag] = []
+        for tag in tags.sorted(by: { $0.sortOrder < $1.sortOrder }) {
+            let name = tag.name.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !name.isEmpty, !tag.id.isEmpty, seenIds.insert(tag.id).inserted else { continue }
+
+            var clean = tag
+            clean.name = name
+            clean.colorIndex = AllocationTagPalette.clampIndex(tag.colorIndex)
+            if let asset = tag.iconAssetName, UIImage(named: asset) == nil {
+                clean.iconAssetName = nil
+            }
+            // Densified rather than preserved: gaps and duplicates in sortOrder make reordering
+            // ambiguous, and the sorted() above already fixed the relative order.
+            clean.sortOrder = cleanTags.count
+            cleanTags.append(clean)
+        }
+
+        let liveIds = Set(cleanTags.map { $0.id })
+        let cleanMap = categoryTagIds.filter { key, tagId in
+            validCategoryKeys.contains(key) && liveIds.contains(tagId)
+        }
+
+        return AllocationTagBook(
+            schemaVersion: Self.currentSchemaVersion,
+            tags: cleanTags,
+            categoryTagIds: cleanMap,
+            updatedAt: updatedAt
+        )
+    }
+}

--- a/Finova/Sources/Core/Models/AllocationTagBreakdown.swift
+++ b/Finova/Sources/Core/Models/AllocationTagBreakdown.swift
@@ -1,0 +1,317 @@
+//
+//  AllocationTagBreakdown.swift
+//  Finova
+//
+//  Created by Arthur Rios on 04/08/26.
+//
+
+import CoreGraphics
+import Foundation
+
+/// What each tag costs in one month, and the order the donut has to draw its slices in.
+///
+/// Like `AllocationBalanceProjection`, this type *consumes* values and computes nothing it could
+/// fetch: no repository, no service, no `Date()`. That is what makes it scope-correct for free - the
+/// caller hands it the arrays `BudgetAllocationService` already filtered by `LedgerScope`, with
+/// `usedAmount` already keyed on by category, so a per-tag subtotal cannot disagree with the card it
+/// sits on. Reaching for a repository from in here would silently break group scoping.
+struct AllocationTagBreakdown: Equatable {
+
+    // MARK: - Segment
+
+    /// One drawable slice of the donut, in draw order.
+    struct Segment: Equatable, Identifiable {
+
+        enum Kind: Equatable {
+            /// A category with a budget allocation.
+            case allocated(categoryKey: String)
+            /// A category that was spent in without an allocation - the card's grey slices.
+            case offPlan(categoryKey: String)
+            /// Budget cap never earmarked to any category.
+            case headroom
+        }
+
+        let id: String
+        let kind: Kind
+        /// The slice's share of the angular domain, in minor units.
+        let amount: Int
+        /// `nil` for untagged categories, and always `nil` for `.headroom`.
+        let tagId: String?
+
+        var categoryKey: String? {
+            switch kind {
+            case .allocated(let key), .offPlan(let key): return key
+            case .headroom: return nil
+            }
+        }
+    }
+
+    // MARK: - Bucket
+
+    /// The money figures for one group of categories. Shared shape between a real tag and the
+    /// untagged remainder so the chip strip can render both from one type.
+    struct Bucket: Equatable {
+        /// Σ allocated over member categories. **This is the sub-budget figure** the chip leads with.
+        let allocated: Int
+        /// Everything spent in member categories, planned or not. Deliberately uncapped, so
+        /// `allocated - used` is an honest "left in this group" and may go negative.
+        let used: Int
+        /// Allocated but not yet spent, clamped per category.
+        let unspent: Int
+        /// Category overruns plus everything spent in member categories with no allocation.
+        let overspent: Int
+        /// Spend in member categories that had no allocation at all.
+        let offPlan: Int
+        /// The bucket's share of the donut's angular domain.
+        let angularAmount: Int
+        /// Fraction of the month's total budget this group plans to consume, 0...1.
+        let share: Double
+
+        var remaining: Int { allocated - used }
+        var isOverspent: Bool { remaining < 0 }
+    }
+
+    /// A `Bucket` that owns a contiguous arc of the ring.
+    struct TagArc: Equatable, Identifiable {
+        let tag: AllocationTag
+        let bucket: Bucket
+        /// Segment ids belonging to this tag, for dimming non-members.
+        let memberSegmentIDs: Set<String>
+        /// Arc boundaries as fractions of the full circle, 0...1.
+        let startFraction: Double
+        let endFraction: Double
+
+        var id: String { tag.id }
+    }
+
+    // MARK: - Stored
+
+    let segments: [Segment]
+    let tagArcs: [TagArc]
+    /// Categories with money this month that belong to no tag. Absent when there is nothing untagged.
+    let untagged: Bucket?
+    /// Budget cap never earmarked, clamped at zero.
+    let headroom: Int
+    /// The denominator the donut normalises by. Must equal what the chart sums, or the ring and the
+    /// slices drift apart.
+    let angularTotal: Int
+    let totalBudget: Int
+
+    /// True when at least one tag has an arc this month. The card keys its whole appearance off this:
+    /// false means render exactly as the app did before tags existed.
+    var hasTags: Bool { !tagArcs.isEmpty }
+
+    static let empty = AllocationTagBreakdown(
+        segments: [], tagArcs: [], untagged: nil, headroom: 0, angularTotal: 0, totalBudget: 0)
+
+    private init(
+        segments: [Segment],
+        tagArcs: [TagArc],
+        untagged: Bucket?,
+        headroom: Int,
+        angularTotal: Int,
+        totalBudget: Int
+    ) {
+        self.segments = segments
+        self.tagArcs = tagArcs
+        self.untagged = untagged
+        self.headroom = headroom
+        self.angularTotal = angularTotal
+        self.totalBudget = totalBudget
+    }
+
+    // MARK: - Building
+
+    /// - Parameters:
+    ///   - allocations: the month's allocations, already scope-filtered with `usedAmount` populated.
+    ///   - unallocatedSpending: spend in categories with no allocation, already scope-filtered.
+    ///   - unallocatedHeadroom: `UnallocatedBudgetSummary.unallocatedAmount`. Clamped at zero here -
+    ///     over-allocating is not overspending, and the footer already warns about it in amber.
+    ///   - totalBudget: the month's cap, used only as the denominator for `share`.
+    init(
+        allocations: [BudgetAllocation],
+        unallocatedSpending: [UnallocatedCategorySpending],
+        unallocatedHeadroom: Int,
+        totalBudget: Int,
+        tags: [AllocationTag],
+        categoryTagIds: [String: String]
+    ) {
+        let effectiveHeadroom = max(0, unallocatedHeadroom)
+
+        // Only tags that actually have money this month get an arc. A tag whose categories are all
+        // idle would otherwise draw a zero-width band and show a 0-value chip, which reads as a bug.
+        var allocationsByTag: [String: [BudgetAllocation]] = [:]
+        var spendingByTag: [String: [UnallocatedCategorySpending]] = [:]
+        var untaggedAllocations: [BudgetAllocation] = []
+        var untaggedSpending: [UnallocatedCategorySpending] = []
+
+        for allocation in allocations {
+            if let tagId = categoryTagIds[allocation.category.key], tags.contains(where: { $0.id == tagId }) {
+                allocationsByTag[tagId, default: []].append(allocation)
+            } else {
+                untaggedAllocations.append(allocation)
+            }
+        }
+        for spending in unallocatedSpending {
+            if let tagId = categoryTagIds[spending.category.key], tags.contains(where: { $0.id == tagId }) {
+                spendingByTag[tagId, default: []].append(spending)
+            } else {
+                untaggedSpending.append(spending)
+            }
+        }
+
+        // Split across three statements rather than one chained sum: the single expression tipped the
+        // type checker into an exponential solve ("unable to type-check in reasonable time").
+        let allocatedTotal: Int = allocations.reduce(0) { $0 + $1.allocatedAmount }
+        let offPlanTotal: Int = unallocatedSpending.reduce(0) { $0 + $1.spentAmount }
+        let total: Int = allocatedTotal + offPlanTotal + effectiveHeadroom
+
+        // Tag order is total desc, then sortOrder, then id. The last two make it a *total* order:
+        // without them two equal-value tags could swap places between launches and the donut would
+        // visibly reshuffle for no reason.
+        let liveTags = tags.filter { tag in
+            !(allocationsByTag[tag.id] ?? []).isEmpty || !(spendingByTag[tag.id] ?? []).isEmpty
+        }
+        let orderedTags = liveTags.sorted { lhs, rhs in
+            let l = Self.angularAmount(allocationsByTag[lhs.id], spendingByTag[lhs.id])
+            let r = Self.angularAmount(allocationsByTag[rhs.id], spendingByTag[rhs.id])
+            if l != r { return l > r }
+            if lhs.sortOrder != rhs.sortOrder { return lhs.sortOrder < rhs.sortOrder }
+            return lhs.id < rhs.id
+        }
+
+        var builtSegments: [Segment] = []
+        var builtArcs: [TagArc] = []
+        var cumulative = 0
+
+        for tag in orderedTags {
+            let members = Self.sortedSegments(
+                allocations: allocationsByTag[tag.id] ?? [],
+                spending: spendingByTag[tag.id] ?? [],
+                tagId: tag.id)
+            guard !members.isEmpty else { continue }
+
+            let start = cumulative
+            builtSegments.append(contentsOf: members)
+            cumulative += members.reduce(0) { $0 + $1.amount }
+
+            builtArcs.append(
+                TagArc(
+                    tag: tag,
+                    bucket: Self.bucket(
+                        allocations: allocationsByTag[tag.id] ?? [],
+                        spending: spendingByTag[tag.id] ?? [],
+                        totalBudget: totalBudget),
+                    memberSegmentIDs: Set(members.map { $0.id }),
+                    startFraction: total > 0 ? Double(start) / Double(total) : 0,
+                    endFraction: total > 0 ? Double(cumulative) / Double(total) : 0))
+        }
+
+        // Untagged next, then headroom last, so the tag arcs stay contiguous from 12 o'clock.
+        builtSegments.append(contentsOf: Self.sortedSegments(
+            allocations: untaggedAllocations, spending: untaggedSpending, tagId: nil))
+
+        if effectiveHeadroom > 0 {
+            builtSegments.append(
+                Segment(id: "headroom", kind: .headroom, amount: effectiveHeadroom, tagId: nil))
+        }
+
+        let untaggedBucket: Bucket?
+        if builtArcs.isEmpty || (untaggedAllocations.isEmpty && untaggedSpending.isEmpty) {
+            // No chip when nothing is tagged: a lone "Untagged" covering the whole budget is noise.
+            untaggedBucket = nil
+        } else {
+            untaggedBucket = Self.bucket(
+                allocations: untaggedAllocations, spending: untaggedSpending, totalBudget: totalBudget)
+        }
+
+        self.segments = builtSegments
+        self.tagArcs = builtArcs
+        self.untagged = untaggedBucket
+        self.headroom = effectiveHeadroom
+        self.angularTotal = total
+        self.totalBudget = totalBudget
+    }
+
+    // MARK: - Lookup
+
+    func arc(id tagId: String) -> TagArc? {
+        tagArcs.first { $0.id == tagId }
+    }
+
+    /// Whether a segment belongs to the given tag - the question the donut asks to decide dimming.
+    func segment(_ segmentId: String, belongsTo tagId: String) -> Bool {
+        arc(id: tagId)?.memberSegmentIDs.contains(segmentId) ?? false
+    }
+
+    // MARK: - Helpers
+
+    private static func angularAmount(
+        _ allocations: [BudgetAllocation]?,
+        _ spending: [UnallocatedCategorySpending]?
+    ) -> Int {
+        (allocations ?? []).reduce(0) { $0 + $1.allocatedAmount }
+            + (spending ?? []).reduce(0) { $0 + $1.spentAmount }
+    }
+
+    /// Allocated members first by amount desc, then off-plan members by amount desc. Category key
+    /// breaks ties so the order is stable across launches.
+    private static func sortedSegments(
+        allocations: [BudgetAllocation],
+        spending: [UnallocatedCategorySpending],
+        tagId: String?
+    ) -> [Segment] {
+        let allocated = allocations
+            .sorted { lhs, rhs in
+                lhs.allocatedAmount == rhs.allocatedAmount
+                    ? lhs.category.key < rhs.category.key
+                    : lhs.allocatedAmount > rhs.allocatedAmount
+            }
+            .map {
+                Segment(
+                    id: "alloc-\($0.category.key)",
+                    kind: .allocated(categoryKey: $0.category.key),
+                    amount: $0.allocatedAmount,
+                    tagId: tagId)
+            }
+
+        let offPlan = spending
+            .sorted { lhs, rhs in
+                lhs.spentAmount == rhs.spentAmount
+                    ? lhs.category.key < rhs.category.key
+                    : lhs.spentAmount > rhs.spentAmount
+            }
+            .map {
+                Segment(
+                    id: "offplan-\($0.category.key)",
+                    kind: .offPlan(categoryKey: $0.category.key),
+                    amount: $0.spentAmount,
+                    tagId: tagId)
+            }
+
+        return allocated + offPlan
+    }
+
+    private static func bucket(
+        allocations: [BudgetAllocation],
+        spending: [UnallocatedCategorySpending],
+        totalBudget: Int
+    ) -> Bucket {
+        let allocated = allocations.reduce(0) { $0 + $1.allocatedAmount }
+        let offPlan = spending.reduce(0) { $0 + $1.spentAmount }
+        let usedInAllocations = allocations.reduce(0) { $0 + $1.usedAmount }
+
+        return Bucket(
+            allocated: allocated,
+            used: usedInAllocations + offPlan,
+            // Borrowed rather than recomputed, so a tag's figures can never drift from the card's.
+            unspent: AllocationBalanceProjection.unspent(allocations: allocations),
+            overspent: AllocationBalanceProjection.overspent(
+                allocations: allocations, unallocatedSpending: offPlan),
+            offPlan: offPlan,
+            angularAmount: allocated + offPlan,
+            // `allocated`, not `angularAmount`: "% of budget" means how much of the cap this group
+            // *plans* to consume. Off-plan spend has no plan behind it and must not inflate that.
+            share: totalBudget > 0 ? Double(allocated) / Double(totalBudget) : 0)
+    }
+}

--- a/Finova/Sources/Core/Models/AllocationTagBreakdown.swift
+++ b/Finova/Sources/Core/Models/AllocationTagBreakdown.swift
@@ -256,6 +256,12 @@ struct AllocationTagBreakdown: Equatable {
 
     /// Allocated members first by amount desc, then off-plan members by amount desc. Category key
     /// breaks ties so the order is stable across launches.
+    ///
+    /// Note this *sorts* rather than preserving caller order, which changes the donut even for a user
+    /// with no tags: `MonthCarouselCell` sorts its allocations amount-desc for the list but hands the
+    /// card the unsorted array, so slices were previously drawn in whatever order the service returned
+    /// - roughly creation order - and disagreed with the list directly beneath them. Sorting here makes
+    /// the two agree. Deliberate, and the only visible change for someone who never makes a tag.
     private static func sortedSegments(
         allocations: [BudgetAllocation],
         spending: [UnallocatedCategorySpending],

--- a/Finova/Sources/Core/Models/AllocationTagPalette.swift
+++ b/Finova/Sources/Core/Models/AllocationTagPalette.swift
@@ -60,10 +60,13 @@ enum AllocationTagPalette {
     /// which owns the category ramp sitting 3pt outside the tag ring.
     ///
     /// One adjacency worth knowing about rather than pretending away: `rose` (351) is close in hue to
-    /// `Colors.brightRed` (0) and `orange` (27) to `Colors.warningAmber` (38). Neither reserved colour
-    /// is ever drawn on the tag ring - amber is the footer's over-allocation value and red lives in
-    /// the projection block - so they cannot appear side by side with a tag arc.
-    static let assignmentOrder: [Int] = [5, 4, 3, 2, 0, 1, 6, 7]
+    /// `Colors.brightRed` (0), `lime`'s ink tone reads as a green, and `orange` (27) is near
+    /// `Colors.warningAmber` (38). None of those reserved colours is ever drawn on the tag ring - amber
+    /// is the footer's over-allocation value and red/green live in the projection block - but on the
+    /// light tag list a crimson or olive row still *reads* faintly like a status. Order within the
+    /// first four is unconstrained by the 60-degree rule, so indigo and teal go first and the two
+    /// status-adjacent tones come third and fourth.
+    static let assignmentOrder: [Int] = [5, 2, 3, 4, 0, 1, 6, 7]
 
     /// Clamps any stored index onto the table, so a corrupt or downgraded value degrades to a
     /// wrong-but-valid colour instead of trapping.

--- a/Finova/Sources/Core/Models/AllocationTagPalette.swift
+++ b/Finova/Sources/Core/Models/AllocationTagPalette.swift
@@ -1,0 +1,98 @@
+//
+//  AllocationTagPalette.swift
+//  Finova
+//
+//  Created by Arthur Rios on 04/08/26.
+//
+
+import UIKit
+
+/// The fixed set of colours an allocation tag can take.
+///
+/// Fixed rather than free-form for three reasons: every tone has to stay legible on two very
+/// different surfaces (see below), the tag ring sits 3pt inside a magenta category ramp and must not
+/// collide with it, and a future group/cloud-backed tag book would otherwise have to negotiate
+/// colours between devices. A stored index into this table sidesteps all of it.
+enum AllocationTagPalette {
+
+    /// A tag colour, in the two tones the app actually needs.
+    ///
+    /// One hex cannot serve both surfaces. The tag ring is drawn on `Colors.gradientBlack`, so it
+    /// needs a *bright* tone; the chip strip and the tag list sit on `Colors.gray100`, and a selected
+    /// chip fills with its tag colour and puts `gray100` text on top, so that needs a *dark* tone.
+    /// The luminance windows for 3:1 on black and 4.5:1 on near-white do not overlap for any vivid
+    /// hue. `CardColor` (`Core/Models/CreditCard.swift`) already splits a colour in two for the same
+    /// kind of reason.
+    struct Entry {
+        let name: String
+        /// For the tag ring on the dark card.
+        let arc: UIColor
+        /// For chips, dots and list rows on light surfaces.
+        let ink: UIColor
+    }
+
+    /// Index order is storage order and must never be reordered - `AllocationTag.colorIndex` points
+    /// into it. To change which colour a new tag gets first, edit `assignmentOrder`, not this.
+    static let entries: [Entry] = [
+        Entry(name: "sky", arc: UIColor(hex: "#38BDF8"), ink: UIColor(hex: "#075985")),
+        Entry(name: "orange", arc: UIColor(hex: "#FB923C"), ink: UIColor(hex: "#C2410C")),
+        Entry(name: "teal", arc: UIColor(hex: "#2DD4BF"), ink: UIColor(hex: "#115E59")),
+        Entry(name: "rose", arc: UIColor(hex: "#FB7185"), ink: UIColor(hex: "#BE123C")),
+        Entry(name: "lime", arc: UIColor(hex: "#A3E635"), ink: UIColor(hex: "#4D7C0F")),
+        Entry(name: "indigo", arc: UIColor(hex: "#818CF8"), ink: UIColor(hex: "#4F46E5")),
+        Entry(name: "green", arc: UIColor(hex: "#4ADE80"), ink: UIColor(hex: "#15803D")),
+        Entry(name: "violet", arc: UIColor(hex: "#C084FC"), ink: UIColor(hex: "#7E22CE")),
+    ]
+
+    static var count: Int { entries.count }
+
+    /// The order new tags claim colours in - chosen for hue spread, not for `entries` order.
+    ///
+    /// Hues: sky 198, orange 27, teal 173, rose 351, lime 83, indigo 235, green 142, violet 270.
+    ///
+    /// The first four are `indigo, lime, rose, teal`, which is the *only* four-subset of this palette
+    /// whose members are all more than 60 apart (its tightest pair is teal/indigo at 62). That matters
+    /// because most users will make two or three tags, and the 7pt ring gives colour alone to tell
+    /// them apart - assigning `sky` then `teal`, only 26 apart, would have handed a user two arcs in
+    /// the same cyan. `AllocationTagPaletteTests` asserts the 60 floor so this cannot regress.
+    ///
+    /// Violet is deliberately last: at 270 it is the closest entry to `Colors.mainMagenta` (299),
+    /// which owns the category ramp sitting 3pt outside the tag ring.
+    ///
+    /// One adjacency worth knowing about rather than pretending away: `rose` (351) is close in hue to
+    /// `Colors.brightRed` (0) and `orange` (27) to `Colors.warningAmber` (38). Neither reserved colour
+    /// is ever drawn on the tag ring - amber is the footer's over-allocation value and red lives in
+    /// the projection block - so they cannot appear side by side with a tag arc.
+    static let assignmentOrder: [Int] = [5, 4, 3, 2, 0, 1, 6, 7]
+
+    /// Clamps any stored index onto the table, so a corrupt or downgraded value degrades to a
+    /// wrong-but-valid colour instead of trapping.
+    static func entry(at index: Int) -> Entry {
+        entries[clampIndex(index)]
+    }
+
+    static func clampIndex(_ index: Int) -> Int {
+        abs(index) % count
+    }
+
+    /// The colour a newly created tag should take: the first unclaimed one in `assignmentOrder`.
+    ///
+    /// Past eight tags it returns the least-used index, ties broken by assignment order. Pure and
+    /// deterministic on purpose - deleting a tag frees its colour for the next one, which is what a
+    /// user expects after deleting and recreating.
+    static func nextColorIndex(existing: [AllocationTag]) -> Int {
+        var uses = [Int](repeating: 0, count: count)
+        for tag in existing {
+            uses[clampIndex(tag.colorIndex)] += 1
+        }
+
+        var best = assignmentOrder.first ?? 0
+        var bestUses = Int.max
+        for index in assignmentOrder where uses[index] < bestUses {
+            best = index
+            bestUses = uses[index]
+            if bestUses == 0 { break }
+        }
+        return best
+    }
+}

--- a/Finova/Sources/Core/Services/AllocationTagService.swift
+++ b/Finova/Sources/Core/Services/AllocationTagService.swift
@@ -1,0 +1,167 @@
+//
+//  AllocationTagService.swift
+//  Finova
+//
+//  Created by Arthur Rios on 04/08/26.
+//
+
+import Foundation
+
+/// The only type UI touches to read or change allocation tags.
+///
+/// Holds the decoded book in memory because the dashboard needs the category map on every rebuild -
+/// per visible carousel cell, per layout pass - and decoding a blob there would be wasteful. The cache
+/// is dropped whenever the signed-in uid changes, so switching accounts can never show the previous
+/// account's grouping.
+final class AllocationTagService {
+
+    static let shared = AllocationTagService()
+
+    private let store: AllocationTagStoring
+    private let uidProvider: () -> String?
+
+    private var cached: AllocationTagBook?
+    /// The uid `cached` was loaded under, so an account switch invalidates rather than persists.
+    private var cachedUid: String?
+
+    init(
+        store: AllocationTagStoring = UserDefaultsAllocationTagStore(),
+        uidProvider: @escaping () -> String? = { UIDUserDefaultsManager.shared.currentUserUID }
+    ) {
+        self.store = store
+        self.uidProvider = uidProvider
+    }
+
+    // MARK: - Reading
+
+    var book: AllocationTagBook {
+        let uid = uidProvider()
+        if let cached, cachedUid == uid { return cached }
+
+        let loaded = store.load()
+        cached = loaded
+        cachedUid = uid
+        return loaded
+    }
+
+    var tags: [AllocationTag] { book.orderedTags }
+
+    var hasTags: Bool { !book.tags.isEmpty }
+
+    func tag(id: String) -> AllocationTag? { book.tag(id: id) }
+
+    func tag(forCategoryKey key: String) -> AllocationTag? {
+        guard let id = book.tagId(forCategoryKey: key) else { return nil }
+        return book.tag(id: id)
+    }
+
+    func categoryKeys(forTagId tagId: String) -> [String] {
+        book.categoryKeys(forTagId: tagId)
+    }
+
+    func categoryCount(forTagId tagId: String) -> Int {
+        book.categoryTagIds.values.reduce(0) { $0 + ($1 == tagId ? 1 : 0) }
+    }
+
+    /// Drops the in-memory copy. Call on sign-in/sign-out, where the uid changes outside our sight.
+    func invalidateCache() {
+        cached = nil
+        cachedUid = nil
+    }
+
+    // MARK: - Writing
+
+    @discardableResult
+    func createTag(name: String) -> AllocationTag? {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        var current = book
+        let tag = AllocationTag(
+            name: trimmed,
+            colorIndex: AllocationTagPalette.nextColorIndex(existing: current.tags),
+            sortOrder: current.tags.count
+        )
+        current.tags.append(tag)
+        commit(current)
+        return tag
+    }
+
+    func rename(tagId: String, to name: String) {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        mutateTag(tagId) { $0.name = trimmed }
+    }
+
+    func setColorIndex(_ index: Int, forTagId tagId: String) {
+        mutateTag(tagId) { $0.colorIndex = AllocationTagPalette.clampIndex(index) }
+    }
+
+    /// `nil` restores the default glyph.
+    func setIconAssetName(_ assetName: String?, forTagId tagId: String) {
+        mutateTag(tagId) { $0.iconAssetName = assetName }
+    }
+
+    /// Removes the tag and every category link pointing at it. Allocations and transactions are
+    /// untouched - a tag is a lens over them, never their owner.
+    func deleteTag(id tagId: String) {
+        var current = book
+        current.tags.removeAll { $0.id == tagId }
+        current.categoryTagIds = current.categoryTagIds.filter { $0.value != tagId }
+        commit(current)
+    }
+
+    /// Assigns a category to a tag. The map is 1:1, so this *moves* the category out of whatever tag
+    /// held it - the callers that need to warn about that ask `tag(forCategoryKey:)` first.
+    func assign(categoryKey: String, toTagId tagId: String) {
+        guard book.tag(id: tagId) != nil else { return }
+        var current = book
+        current.categoryTagIds[categoryKey] = tagId
+        commit(current)
+    }
+
+    func unassign(categoryKey: String) {
+        var current = book
+        current.categoryTagIds.removeValue(forKey: categoryKey)
+        commit(current)
+    }
+
+    /// `orderedIds` is the new display order; ids not present keep their relative order behind them.
+    func reorder(tagIds orderedIds: [String]) {
+        var current = book
+        let rank = Dictionary(uniqueKeysWithValues: orderedIds.enumerated().map { ($1, $0) })
+        current.tags = current.tags
+            .sorted { lhs, rhs in
+                let l = rank[lhs.id] ?? Int.max
+                let r = rank[rhs.id] ?? Int.max
+                return l == r ? lhs.sortOrder < rhs.sortOrder : l < r
+            }
+            .enumerated()
+            .map { index, tag in
+                var copy = tag
+                copy.sortOrder = index
+                return copy
+            }
+        commit(current)
+    }
+
+    // MARK: - Plumbing
+
+    private func mutateTag(_ tagId: String, _ change: (inout AllocationTag) -> Void) {
+        var current = book
+        guard let index = current.tags.firstIndex(where: { $0.id == tagId }) else { return }
+        change(&current.tags[index])
+        commit(current)
+    }
+
+    /// Single write path: persist, refresh the cache from what was actually stored (so callers see the
+    /// sanitised truth rather than their own optimistic copy), then notify.
+    private func commit(_ book: AllocationTagBook) {
+        store.save(book)
+        cached = nil
+        cachedUid = nil
+        _ = self.book
+
+        NotificationCenter.default.post(name: .allocationTagsChanged, object: nil)
+    }
+}

--- a/Finova/Sources/Core/Services/AllocationTagStore.swift
+++ b/Finova/Sources/Core/Services/AllocationTagStore.swift
@@ -1,0 +1,112 @@
+//
+//  AllocationTagStore.swift
+//  Finova
+//
+//  Created by Arthur Rios on 04/08/26.
+//
+
+import Foundation
+
+// MARK: - Protocol
+
+/// Persistence seam for the tag book.
+///
+/// The v1 implementation is a per-uid `UserDefaults` blob, which is device-local. The protocol exists
+/// so the cloud-backed replacement - one settings `CKRecord` carrying the whole book, resolved
+/// last-writer-wins on `updatedAt` - is a drop-in that no UI has to know about. Do not let callers
+/// depend on anything below beyond these two methods.
+protocol AllocationTagStoring: AnyObject {
+    func load() -> AllocationTagBook
+    /// A no-op when the loaded book could not be trusted; see `UserDefaultsAllocationTagStore`.
+    func save(_ book: AllocationTagBook)
+}
+
+// MARK: - UserDefaults implementation
+
+final class UserDefaultsAllocationTagStore: AllocationTagStoring {
+
+    /// Versioned in the key as well as the payload. The key version lets a future incompatible format
+    /// live alongside this one and be ignored without shipping a decoder for it; `schemaVersion`
+    /// inside the payload covers additive migrations under the same key.
+    private static let keyPrefix = "allocationTagBook_v1_"
+
+    private let defaults: UserDefaults
+    private let uidProvider: () -> String?
+
+    /// Set when a stored book could not be trusted. While true, `save` refuses to write.
+    ///
+    /// A decode failure must never become data loss: the bytes we could not parse may be a newer
+    /// format, or the victim of a bug we are about to fix. Overwriting them with `.empty` would
+    /// silently destroy every tag the user made.
+    private(set) var isReadOnly = false
+
+    /// Both dependencies are injected because the tests must not touch `UserDefaults.standard` - the
+    /// rest of the app hardcodes it, and a test run would otherwise mutate the developer's own state.
+    init(
+        defaults: UserDefaults = .standard,
+        uidProvider: @escaping () -> String? = { UIDUserDefaultsManager.shared.currentUserUID }
+    ) {
+        self.defaults = defaults
+        self.uidProvider = uidProvider
+    }
+
+    func load() -> AllocationTagBook {
+        // No uid means no signed-in user. Deliberately does not fall back to an unkeyed slot: tags
+        // are per-account, and a shared slot would leak one account's grouping into another's.
+        guard let key = storageKey() else { return .empty }
+        guard let data = defaults.data(forKey: key) else {
+            isReadOnly = false
+            return .empty
+        }
+
+        do {
+            let decoded = try JSONDecoder().decode(AllocationTagBook.self, from: data)
+            if decoded.schemaVersion > AllocationTagBook.currentSchemaVersion {
+                // Only reachable by installing an older build over a newer one. Show what we can
+                // understand, but never write our older shape back over it.
+                logWarning(
+                    "[AllocationTags] Book schemaVersion \(decoded.schemaVersion) is newer than "
+                        + "\(AllocationTagBook.currentSchemaVersion); treating as read-only")
+                isReadOnly = true
+            } else {
+                isReadOnly = false
+            }
+            return decoded.sanitized()
+        } catch {
+            logError("[AllocationTags] Failed to decode tag book: \(error). Keeping stored bytes.")
+            isReadOnly = true
+            return .empty
+        }
+    }
+
+    func save(_ book: AllocationTagBook) {
+        guard !isReadOnly else {
+            logWarning("[AllocationTags] Refusing to write over a book that could not be read")
+            return
+        }
+        guard let key = storageKey() else {
+            logError("[AllocationTags] Cannot save tag book: no current user UID")
+            return
+        }
+
+        var toStore = book.sanitized()
+        toStore.updatedAt = Date()
+
+        do {
+            defaults.set(try JSONEncoder().encode(toStore), forKey: key)
+        } catch {
+            logError("[AllocationTags] Failed to encode tag book: \(error)")
+        }
+    }
+
+    /// Exposed for the sign-out path only. Not part of `AllocationTagStoring`: deleting a user's
+    /// groupings is a decision the account lifecycle makes, not something tag callers should reach for.
+    func removeBook(forUid uid: String) {
+        defaults.removeObject(forKey: Self.keyPrefix + uid)
+    }
+
+    private func storageKey() -> String? {
+        guard let uid = uidProvider(), !uid.isEmpty else { return nil }
+        return Self.keyPrefix + uid
+    }
+}

--- a/Finova/Sources/Scenes/AllocationTagCategories/AllocationTagCategoriesView.swift
+++ b/Finova/Sources/Scenes/AllocationTagCategories/AllocationTagCategoriesView.swift
@@ -1,0 +1,172 @@
+//
+//  AllocationTagCategoriesView.swift
+//  Finova
+//
+//  Created by Arthur Rios on 04/08/26.
+//
+
+import UIKit
+
+protocol AllocationTagCategoriesViewDelegate: AnyObject {
+    func didTapBackButton()
+}
+
+final class AllocationTagCategoriesView: UIView {
+
+    weak var delegate: AllocationTagCategoriesViewDelegate?
+
+    private let headerContainerView: UIView = {
+        let view = UIView()
+        view.backgroundColor = Colors.gray100
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.heightAnchor.constraint(equalToConstant: Metrics.headerHeight).isActive = true
+        return view
+    }()
+
+    private let headerItemsView: UIView = {
+        let view = UIView()
+        view.directionalLayoutMargins = NSDirectionalEdgeInsets(
+            top: Metrics.spacing4, leading: Metrics.spacing5, bottom: Metrics.spacing5,
+            trailing: Metrics.spacing5)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private let backButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setImage(UIImage(named: "chevronLeft")?.withRenderingMode(.alwaysTemplate), for: .normal)
+        button.imageView?.contentMode = .scaleAspectFit
+        button.translatesAutoresizingMaskIntoConstraints = false
+        if #available(iOS 26.0, *) {
+            button.tintColor = Colors.gray700
+        } else {
+            button.tintColor = Colors.gray500
+        }
+        return button
+    }()
+
+    private lazy var backButtonGlassContainer: UIView = {
+        let container = UIView()
+        container.translatesAutoresizingMaskIntoConstraints = false
+        return container
+    }()
+
+    private let headerTitleLabel: UILabel = {
+        let label = UILabel()
+        label.fontStyle = Fonts.titleSM
+        label.applyStyle()
+        label.textColor = Colors.gray700
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private let headerSubtitleLabel: UILabel = {
+        let label = UILabel()
+        label.font = Fonts.textSM.font
+        label.text = "allocationTags.categories.subtitle".localized
+        label.textColor = Colors.gray500
+        label.numberOfLines = 2
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private lazy var headerTextStackView = UIStackView(
+        axis: .vertical, spacing: Metrics.spacing1,
+        arrangedSubviews: [headerTitleLabel, headerSubtitleLabel])
+
+    let tableView: UITableView = {
+        let table = UITableView(frame: .zero, style: .plain)
+        table.backgroundColor = Colors.gray100
+        table.separatorStyle = .singleLine
+        table.separatorInset = .zero
+        table.separatorColor = Colors.gray300
+        table.layer.borderWidth = 1
+        table.layer.borderColor = Colors.gray300.cgColor
+        table.layer.cornerRadius = CornerRadius.extraLarge
+        table.clipsToBounds = true
+        table.showsVerticalScrollIndicator = false
+        table.translatesAutoresizingMaskIntoConstraints = false
+        return table
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = Colors.gray200
+        setupView()
+        setupLayout()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupView() {
+        addSubview(headerContainerView)
+        headerContainerView.addSubview(headerItemsView)
+        headerItemsView.addSubview(backButtonGlassContainer)
+        backButtonGlassContainer.addSubview(backButton)
+        headerItemsView.addSubview(headerTextStackView)
+        headerTextStackView.translatesAutoresizingMaskIntoConstraints = false
+
+        addSubview(tableView)
+
+        if #available(iOS 26.0, *) {
+            let glass = UIGlassEffect(style: .clear)
+            glass.isInteractive = true
+            let glassView = UIVisualEffectView(effect: glass)
+            glassView.translatesAutoresizingMaskIntoConstraints = false
+            backButtonGlassContainer.insertSubview(glassView, at: 0)
+            glassView.pinToSuperview()
+            backButtonGlassContainer.layer.cornerRadius = 18
+            backButtonGlassContainer.clipsToBounds = true
+        }
+
+        backButton.addTarget(self, action: #selector(backTapped), for: .touchUpInside)
+    }
+
+    private func setupLayout() {
+        NSLayoutConstraint.activate([
+            headerContainerView.topAnchor.constraint(equalTo: topAnchor),
+            headerContainerView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            headerContainerView.trailingAnchor.constraint(equalTo: trailingAnchor),
+
+            headerItemsView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
+            headerItemsView.leadingAnchor.constraint(equalTo: headerContainerView.leadingAnchor),
+            headerItemsView.trailingAnchor.constraint(equalTo: headerContainerView.trailingAnchor),
+            headerItemsView.bottomAnchor.constraint(equalTo: headerContainerView.bottomAnchor),
+
+            backButtonGlassContainer.topAnchor.constraint(
+                equalTo: headerItemsView.layoutMarginsGuide.topAnchor),
+            backButtonGlassContainer.leadingAnchor.constraint(
+                equalTo: headerItemsView.layoutMarginsGuide.leadingAnchor),
+            backButtonGlassContainer.widthAnchor.constraint(equalToConstant: 36),
+            backButtonGlassContainer.heightAnchor.constraint(equalToConstant: 36),
+
+            backButton.topAnchor.constraint(equalTo: backButtonGlassContainer.topAnchor),
+            backButton.leadingAnchor.constraint(equalTo: backButtonGlassContainer.leadingAnchor),
+            backButton.trailingAnchor.constraint(equalTo: backButtonGlassContainer.trailingAnchor),
+            backButton.bottomAnchor.constraint(equalTo: backButtonGlassContainer.bottomAnchor),
+
+            headerTextStackView.leadingAnchor.constraint(
+                equalTo: backButtonGlassContainer.trailingAnchor, constant: Metrics.spacing4),
+            headerTextStackView.centerYAnchor.constraint(
+                equalTo: backButtonGlassContainer.centerYAnchor),
+            headerTextStackView.trailingAnchor.constraint(
+                lessThanOrEqualTo: headerItemsView.layoutMarginsGuide.trailingAnchor),
+
+            tableView.topAnchor.constraint(
+                equalTo: headerContainerView.bottomAnchor, constant: Metrics.spacing4),
+            tableView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Metrics.spacing4),
+            tableView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Metrics.spacing4),
+            tableView.bottomAnchor.constraint(
+                equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -Metrics.spacing4),
+        ])
+    }
+
+    func configure(tagName: String) {
+        headerTitleLabel.text = tagName
+        headerTitleLabel.applyStyle()
+    }
+
+    @objc private func backTapped() { delegate?.didTapBackButton() }
+}

--- a/Finova/Sources/Scenes/AllocationTagCategories/AllocationTagCategoriesViewController.swift
+++ b/Finova/Sources/Scenes/AllocationTagCategories/AllocationTagCategoriesViewController.swift
@@ -1,0 +1,134 @@
+//
+//  AllocationTagCategoriesViewController.swift
+//  Finova
+//
+//  Created by Arthur Rios on 04/08/26.
+//
+
+import UIKit
+
+/// Links spending categories to one tag.
+///
+/// The map is 1:1 - a category belongs to exactly one tag - because exclusive tags partition the plan,
+/// which is what makes the subtotals add up to the budget and lets the donut draw each tag as one
+/// contiguous arc. That exclusivity is the most confusing thing about the feature, so a category owned
+/// by another tag says so on its row and asks before moving.
+final class AllocationTagCategoriesViewController: UIViewController {
+
+    let contentView: AllocationTagCategoriesView
+    private let tagService: AllocationTagService
+    private let tag: AllocationTag
+    weak var flowDelegate: AllocationTagCategoriesFlowDelegate?
+
+    /// Income-only categories are excluded: a tag answers "what does this group cost", and salary can
+    /// never be part of that. Payment-method categories (`transfer`, `bankSlip`, `creditCard`) stay,
+    /// because real expense transactions do land in them and would otherwise be untaggable.
+    private let categories = TransactionCategory.allCases.filter { $0 != .salary }
+
+    init(
+        contentView: AllocationTagCategoriesView,
+        tag: AllocationTag,
+        tagService: AllocationTagService = .shared,
+        flowDelegate: AllocationTagCategoriesFlowDelegate
+    ) {
+        self.contentView = contentView
+        self.tag = tag
+        self.tagService = tagService
+        self.flowDelegate = flowDelegate
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupContentViewToBounds(contentView: contentView, respectingSafeArea: false)
+        contentView.delegate = self
+        contentView.configure(tagName: tag.name)
+        contentView.tableView.delegate = self
+        contentView.tableView.dataSource = self
+        contentView.tableView.register(
+            AllocationTagCategoryCell.self,
+            forCellReuseIdentifier: AllocationTagCategoryCell.identifier)
+    }
+
+    private func toggle(_ category: TransactionCategory) {
+        let owner = tagService.tag(forCategoryKey: category.key)
+
+        if owner?.id == tag.id {
+            tagService.unassign(categoryKey: category.key)
+            contentView.tableView.reloadData()
+            return
+        }
+
+        guard let owner else {
+            tagService.assign(categoryKey: category.key, toTagId: tag.id)
+            contentView.tableView.reloadData()
+            return
+        }
+
+        // Owned elsewhere: confirm, because the effect is invisible on this screen - the other tag
+        // silently loses a category and its subtotal changes.
+        let alert = UIAlertController(
+            title: "allocationTags.categories.move.title".localized,
+            message: String(
+                format: "allocationTags.categories.move.message".localized,
+                category.displayName, owner.name),
+            preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "alert.cancel".localized, style: .cancel))
+        alert.addAction(
+            UIAlertAction(title: "allocationTags.categories.move.button".localized, style: .default) {
+                [weak self] _ in
+                guard let self else { return }
+                self.tagService.assign(categoryKey: category.key, toTagId: self.tag.id)
+                self.contentView.tableView.reloadData()
+            })
+        present(alert, animated: true)
+    }
+}
+
+// MARK: - AllocationTagCategoriesViewDelegate
+
+extension AllocationTagCategoriesViewController: AllocationTagCategoriesViewDelegate {
+    func didTapBackButton() {
+        flowDelegate?.dismissAllocationTagCategories()
+    }
+}
+
+// MARK: - UITableViewDataSource & UITableViewDelegate
+
+extension AllocationTagCategoriesViewController: UITableViewDataSource, UITableViewDelegate {
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        categories.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard
+            let cell = tableView.dequeueReusableCell(
+                withIdentifier: AllocationTagCategoryCell.identifier, for: indexPath)
+                as? AllocationTagCategoryCell
+        else {
+            return UITableViewCell()
+        }
+
+        let category = categories[indexPath.row]
+        let owner = tagService.tag(forCategoryKey: category.key)
+        cell.configure(
+            category: category,
+            isSelected: owner?.id == tag.id,
+            otherTagName: owner?.id == tag.id ? nil : owner?.name)
+        return cell
+    }
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        toggle(categories[indexPath.row])
+    }
+
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        56
+    }
+}

--- a/Finova/Sources/Scenes/AllocationTagCategories/AllocationTagCategoryCell.swift
+++ b/Finova/Sources/Scenes/AllocationTagCategories/AllocationTagCategoryCell.swift
@@ -1,0 +1,128 @@
+//
+//  AllocationTagCategoryCell.swift
+//  Finova
+//
+//  Created by Arthur Rios on 04/08/26.
+//
+
+import UIKit
+
+final class AllocationTagCategoryCell: UITableViewCell {
+
+    static let identifier = "AllocationTagCategoryCell"
+
+    private let iconContainer: UIView = {
+        let view = UIView()
+        view.layer.cornerRadius = CornerRadius.medium
+        view.backgroundColor = Colors.gray200
+        view.layer.borderColor = Colors.gray300.cgColor
+        view.layer.borderWidth = 1
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private let iconView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFit
+        imageView.tintColor = Colors.gray500
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        return imageView
+    }()
+
+    private let nameLabel: UILabel = {
+        let label = UILabel()
+        label.font = Fonts.textSMBold.font
+        label.textColor = Colors.gray700
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    /// Names the tag that currently owns this category, so a move is never a surprise.
+    private let ownerLabel: UILabel = {
+        let label = UILabel()
+        label.font = Fonts.textXS.font
+        label.textColor = Colors.gray500
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private lazy var textStackView: UIStackView = {
+        let stack = UIStackView(arrangedSubviews: [nameLabel, ownerLabel])
+        stack.axis = .vertical
+        stack.spacing = 2
+        stack.alignment = .leading
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        return stack
+    }()
+
+    private let checkmarkView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = UIImage(systemName: "checkmark")
+        imageView.tintColor = Colors.mainMagenta
+        imageView.contentMode = .scaleAspectFit
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        return imageView
+    }()
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        selectionStyle = .none
+        backgroundColor = .clear
+        contentView.backgroundColor = Colors.gray100
+        setupView()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupView() {
+        contentView.addSubview(iconContainer)
+        iconContainer.addSubview(iconView)
+        contentView.addSubview(textStackView)
+        contentView.addSubview(checkmarkView)
+
+        NSLayoutConstraint.activate([
+            iconContainer.leadingAnchor.constraint(
+                equalTo: contentView.leadingAnchor, constant: Metrics.spacing5),
+            iconContainer.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            iconContainer.widthAnchor.constraint(equalToConstant: Metrics.spacing8),
+            iconContainer.heightAnchor.constraint(equalToConstant: Metrics.spacing8),
+
+            iconView.centerXAnchor.constraint(equalTo: iconContainer.centerXAnchor),
+            iconView.centerYAnchor.constraint(equalTo: iconContainer.centerYAnchor),
+            iconView.widthAnchor.constraint(equalToConstant: Metrics.spacing5),
+            iconView.heightAnchor.constraint(equalToConstant: Metrics.spacing5),
+
+            textStackView.leadingAnchor.constraint(
+                equalTo: iconContainer.trailingAnchor, constant: Metrics.spacing3),
+            textStackView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            textStackView.trailingAnchor.constraint(
+                lessThanOrEqualTo: checkmarkView.leadingAnchor, constant: -Metrics.spacing3),
+
+            checkmarkView.trailingAnchor.constraint(
+                equalTo: contentView.trailingAnchor, constant: -Metrics.spacing5),
+            checkmarkView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            checkmarkView.widthAnchor.constraint(equalToConstant: 16),
+            checkmarkView.heightAnchor.constraint(equalToConstant: 16),
+        ])
+    }
+
+    func configure(category: TransactionCategory, isSelected: Bool, otherTagName: String?) {
+        iconView.image = UIImage(named: category.iconName(for: .expense))?
+            .withRenderingMode(.alwaysTemplate)
+        nameLabel.text = category.displayName
+
+        checkmarkView.isHidden = !isSelected
+        iconView.tintColor = isSelected ? Colors.mainMagenta : Colors.gray500
+
+        if let otherTagName {
+            ownerLabel.text = String(
+                format: "allocationTags.categories.inOtherTag".localized, otherTagName)
+            ownerLabel.isHidden = false
+        } else {
+            ownerLabel.text = nil
+            ownerLabel.isHidden = true
+        }
+    }
+}

--- a/Finova/Sources/Scenes/AllocationTags/AllocationTagCreationPrompt.swift
+++ b/Finova/Sources/Scenes/AllocationTags/AllocationTagCreationPrompt.swift
@@ -1,0 +1,53 @@
+//
+//  AllocationTagCreationPrompt.swift
+//  Finova
+//
+//  Created by Arthur Rios on 04/08/26.
+//
+
+import UIKit
+
+/// The one place a tag gets created from.
+///
+/// Two entry points reach it - the Tags list's `+` button and the `+` chip at the end of the dashboard
+/// strip - and both must behave identically: same wording, same validation, and the same push into the
+/// edit screen afterwards, because a tag with no categories linked does nothing at all. Duplicating the
+/// alert at each call site is how those two drift apart.
+enum AllocationTagCreationPrompt {
+
+    /// - Parameter onCreated: called with the new tag, on the main thread, after it is persisted. The
+    ///   caller decides where to go next - the list pushes edit, the dashboard pushes edit too, but
+    ///   from a different navigation position.
+    static func present(
+        from presenter: UIViewController,
+        tagService: AllocationTagService = .shared,
+        onCreated: @escaping (AllocationTag) -> Void
+    ) {
+        let alert = UIAlertController(
+            title: "allocationTags.create.title".localized,
+            message: "allocationTags.create.message".localized,
+            preferredStyle: .alert)
+
+        alert.addTextField { textField in
+            textField.placeholder = "allocationTags.create.namePlaceholder".localized
+            textField.autocapitalizationType = .words
+        }
+
+        let createAction = UIAlertAction(
+            title: "allocationTags.create.button".localized, style: .default
+        ) { [weak alert] _ in
+            guard
+                let name = alert?.textFields?.first?.text?
+                    .trimmingCharacters(in: .whitespacesAndNewlines),
+                !name.isEmpty,
+                let tag = tagService.createTag(name: name)
+            else { return }
+            onCreated(tag)
+        }
+
+        alert.addAction(createAction)
+        alert.addAction(UIAlertAction(title: "alert.cancel".localized, style: .cancel))
+
+        presenter.present(alert, animated: true)
+    }
+}

--- a/Finova/Sources/Scenes/AllocationTags/AllocationTagEditView.swift
+++ b/Finova/Sources/Scenes/AllocationTags/AllocationTagEditView.swift
@@ -1,0 +1,437 @@
+//
+//  AllocationTagEditView.swift
+//  Finova
+//
+//  Created by Arthur Rios on 04/08/26.
+//
+
+import UIKit
+
+final class AllocationTagEditView: UIView {
+
+    weak var delegate: AllocationTagEditViewDelegate?
+
+    /// The assets offered as tag icons. The whole `lucide_icon*` set the app already ships, in the
+    /// order categories are declared, with the default glyph first. No new artwork.
+    static let iconAssetNames: [String] = {
+        let candidates = TransactionCategory.allCases.map { $0.iconName }
+        var seen = Set<String>()
+        // `iconName` falls back to lucide_iconDollar for cases with no asset, so dedupe rather than
+        // showing the dollar glyph three times.
+        return candidates.filter { seen.insert($0).inserted }
+    }()
+
+    private(set) var selectedColorIndex: Int = 0
+    /// `nil` means the default glyph.
+    private(set) var selectedIconAssetName: String?
+
+    private var colorButtons: [UIButton] = []
+    private var iconButtons: [UIButton] = []
+
+    // MARK: - Header
+
+    private let headerContainerView: UIView = {
+        let view = UIView()
+        view.backgroundColor = Colors.gray100
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.heightAnchor.constraint(equalToConstant: Metrics.headerHeight - 12).isActive = true
+        return view
+    }()
+
+    private let headerItemsView: UIView = {
+        let view = UIView()
+        view.directionalLayoutMargins = NSDirectionalEdgeInsets(
+            top: Metrics.spacing4, leading: Metrics.spacing5, bottom: Metrics.spacing5,
+            trailing: Metrics.spacing5)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private let backButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setImage(UIImage(named: "chevronLeft")?.withRenderingMode(.alwaysTemplate), for: .normal)
+        button.imageView?.contentMode = .scaleAspectFit
+        button.translatesAutoresizingMaskIntoConstraints = false
+        if #available(iOS 26.0, *) {
+            button.tintColor = Colors.gray700
+        } else {
+            button.tintColor = Colors.gray500
+        }
+        return button
+    }()
+
+    private lazy var backButtonGlassContainer: UIView = {
+        let container = UIView()
+        container.translatesAutoresizingMaskIntoConstraints = false
+        return container
+    }()
+
+    private let headerTitleLabel: UILabel = {
+        let label = UILabel()
+        label.fontStyle = Fonts.titleSM
+        label.text = "allocationTags.edit.title".localized
+        label.applyStyle()
+        label.textColor = Colors.gray700
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    // MARK: - Fields
+
+    private let scrollView: UIScrollView = {
+        let scroll = UIScrollView()
+        scroll.showsVerticalScrollIndicator = false
+        scroll.keyboardDismissMode = .interactive
+        scroll.translatesAutoresizingMaskIntoConstraints = false
+        return scroll
+    }()
+
+    private let cardView: UIView = {
+        let view = UIView()
+        view.backgroundColor = Colors.gray100
+        view.layer.cornerRadius = CornerRadius.extraLarge
+        view.layer.borderWidth = 1
+        view.layer.borderColor = Colors.gray300.cgColor
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    let nameInput = ValidatedInput(
+        type: .name, placeholder: "allocationTags.create.namePlaceholder".localized)
+
+    private let colorStackView: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .horizontal
+        stack.spacing = Metrics.spacing3
+        stack.distribution = .fillEqually
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        return stack
+    }()
+
+    /// Scrolls, unlike the colour row: 27-odd icons cannot fit across a phone at a tappable size. It
+    /// stays a `UIStackView` of buttons - the app has no grid pickers, and this is not the place to
+    /// introduce one.
+    private let iconScrollView: UIScrollView = {
+        let scroll = UIScrollView()
+        scroll.showsHorizontalScrollIndicator = false
+        scroll.translatesAutoresizingMaskIntoConstraints = false
+        return scroll
+    }()
+
+    private let iconStackView: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .horizontal
+        stack.spacing = Metrics.spacing3
+        // `.fill` with fixed widths, never `.fillEqually` - that would squash 20+ buttons into the
+        // visible width instead of letting the scroll view do its job.
+        stack.distribution = .fill
+        stack.alignment = .center
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        return stack
+    }()
+
+    private lazy var categoriesRow: UIControl = {
+        let row = UIControl()
+        row.backgroundColor = Colors.gray200
+        row.layer.cornerRadius = CornerRadius.medium
+        row.layer.borderWidth = 1
+        row.layer.borderColor = Colors.gray300.cgColor
+        row.translatesAutoresizingMaskIntoConstraints = false
+        row.heightAnchor.constraint(equalToConstant: Metrics.inputHeight).isActive = true
+
+        let title = UILabel()
+        title.text = "allocationTags.edit.categories.row".localized
+        title.font = Fonts.textSM.font
+        title.textColor = Colors.gray700
+        title.translatesAutoresizingMaskIntoConstraints = false
+
+        let chevron = UIImageView(image: UIImage(systemName: "chevron.right"))
+        chevron.tintColor = Colors.gray400
+        chevron.contentMode = .scaleAspectFit
+        chevron.translatesAutoresizingMaskIntoConstraints = false
+
+        row.addSubview(title)
+        row.addSubview(categoryCountLabel)
+        row.addSubview(chevron)
+
+        NSLayoutConstraint.activate([
+            title.leadingAnchor.constraint(equalTo: row.leadingAnchor, constant: Metrics.spacing4),
+            title.centerYAnchor.constraint(equalTo: row.centerYAnchor),
+
+            chevron.trailingAnchor.constraint(equalTo: row.trailingAnchor, constant: -Metrics.spacing4),
+            chevron.centerYAnchor.constraint(equalTo: row.centerYAnchor),
+            chevron.widthAnchor.constraint(equalToConstant: 12),
+            chevron.heightAnchor.constraint(equalToConstant: 12),
+
+            categoryCountLabel.trailingAnchor.constraint(
+                equalTo: chevron.leadingAnchor, constant: -Metrics.spacing2),
+            categoryCountLabel.centerYAnchor.constraint(equalTo: row.centerYAnchor),
+        ])
+
+        row.addTarget(self, action: #selector(categoriesTapped), for: .touchUpInside)
+        return row
+    }()
+
+    private let categoryCountLabel: UILabel = {
+        let label = UILabel()
+        label.font = Fonts.textSM.font
+        label.textColor = Colors.gray500
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    /// Restyled to red after init rather than using `Button(variant: .outlined)` as-is: that variant
+    /// hardcodes `mainMagenta`, and a destructive action must not wear the brand's primary colour. The
+    /// app has no destructive `Button` variant, and `GroupDetailsView` solves the same problem the same
+    /// way - `Colors.mainRed` applied at the call site.
+    let deleteButton: Button = {
+        let button = Button(
+            variant: .outlined, label: "allocationTags.edit.delete.button".localized)
+        button.setTitleColor(Colors.mainRed, for: .normal)
+        button.layer.borderColor = Colors.mainRed.cgColor
+        button.backgroundColor = Colors.lightRed
+        return button
+    }()
+
+    // MARK: - Init
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = Colors.gray200
+        setupView()
+        setupLayout()
+        buildColorSelector()
+        buildIconSelector()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupView() {
+        addSubview(headerContainerView)
+        headerContainerView.addSubview(headerItemsView)
+        headerItemsView.addSubview(backButtonGlassContainer)
+        backButtonGlassContainer.addSubview(backButton)
+        headerItemsView.addSubview(headerTitleLabel)
+
+        addSubview(scrollView)
+        scrollView.addSubview(cardView)
+
+        iconScrollView.addSubview(iconStackView)
+
+        let fieldsStack = UIStackView(arrangedSubviews: [
+            labeledField(label: "allocationTags.edit.input.name".localized, field: nameInput),
+            labeledField(label: "allocationTags.edit.input.color".localized, field: colorStackView),
+            labeledField(label: "allocationTags.edit.input.icon".localized, field: iconScrollView),
+            categoriesRow,
+            deleteButton,
+        ])
+        fieldsStack.axis = .vertical
+        fieldsStack.spacing = Metrics.spacing5
+        fieldsStack.translatesAutoresizingMaskIntoConstraints = false
+        fieldsStack.directionalLayoutMargins = NSDirectionalEdgeInsets(
+            top: Metrics.spacing5, leading: Metrics.spacing5, bottom: Metrics.spacing5,
+            trailing: Metrics.spacing5)
+        fieldsStack.isLayoutMarginsRelativeArrangement = true
+        cardView.addSubview(fieldsStack)
+        fieldsStack.pinToSuperview()
+
+        if #available(iOS 26.0, *) {
+            let backGlass = UIGlassEffect(style: .clear)
+            backGlass.isInteractive = true
+            let backGlassView = UIVisualEffectView(effect: backGlass)
+            backGlassView.translatesAutoresizingMaskIntoConstraints = false
+            backButtonGlassContainer.insertSubview(backGlassView, at: 0)
+            backGlassView.pinToSuperview()
+            backButtonGlassContainer.layer.cornerRadius = 18
+            backButtonGlassContainer.clipsToBounds = true
+        }
+
+        backButton.addTarget(self, action: #selector(backTapped), for: .touchUpInside)
+        deleteButton.addTarget(self, action: #selector(deleteTapped), for: .touchUpInside)
+        nameInput.textField.addTarget(self, action: #selector(nameChanged), for: .editingChanged)
+    }
+
+    private func setupLayout() {
+        NSLayoutConstraint.activate([
+            headerContainerView.topAnchor.constraint(equalTo: topAnchor),
+            headerContainerView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            headerContainerView.trailingAnchor.constraint(equalTo: trailingAnchor),
+
+            headerItemsView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
+            headerItemsView.leadingAnchor.constraint(equalTo: headerContainerView.leadingAnchor),
+            headerItemsView.trailingAnchor.constraint(equalTo: headerContainerView.trailingAnchor),
+            headerItemsView.bottomAnchor.constraint(equalTo: headerContainerView.bottomAnchor),
+
+            backButtonGlassContainer.topAnchor.constraint(
+                equalTo: headerItemsView.layoutMarginsGuide.topAnchor),
+            backButtonGlassContainer.leadingAnchor.constraint(
+                equalTo: headerItemsView.layoutMarginsGuide.leadingAnchor),
+            backButtonGlassContainer.widthAnchor.constraint(equalToConstant: 36),
+            backButtonGlassContainer.heightAnchor.constraint(equalToConstant: 36),
+
+            backButton.topAnchor.constraint(equalTo: backButtonGlassContainer.topAnchor),
+            backButton.leadingAnchor.constraint(equalTo: backButtonGlassContainer.leadingAnchor),
+            backButton.trailingAnchor.constraint(equalTo: backButtonGlassContainer.trailingAnchor),
+            backButton.bottomAnchor.constraint(equalTo: backButtonGlassContainer.bottomAnchor),
+
+            headerTitleLabel.leadingAnchor.constraint(
+                equalTo: backButtonGlassContainer.trailingAnchor, constant: Metrics.spacing4),
+            headerTitleLabel.centerYAnchor.constraint(
+                equalTo: backButtonGlassContainer.centerYAnchor),
+            headerTitleLabel.trailingAnchor.constraint(
+                lessThanOrEqualTo: headerItemsView.layoutMarginsGuide.trailingAnchor),
+
+            scrollView.topAnchor.constraint(
+                equalTo: headerContainerView.bottomAnchor, constant: Metrics.spacing4),
+            scrollView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor),
+
+            cardView.topAnchor.constraint(equalTo: scrollView.topAnchor),
+            cardView.leadingAnchor.constraint(
+                equalTo: scrollView.leadingAnchor, constant: Metrics.spacing4),
+            cardView.trailingAnchor.constraint(
+                equalTo: scrollView.trailingAnchor, constant: -Metrics.spacing4),
+            cardView.bottomAnchor.constraint(
+                equalTo: scrollView.bottomAnchor, constant: -Metrics.spacing6),
+            cardView.widthAnchor.constraint(
+                equalTo: scrollView.widthAnchor, constant: -Metrics.spacing8),
+
+            nameInput.heightAnchor.constraint(greaterThanOrEqualToConstant: Metrics.inputHeight),
+
+            iconScrollView.heightAnchor.constraint(equalToConstant: 32),
+            iconStackView.topAnchor.constraint(equalTo: iconScrollView.topAnchor),
+            iconStackView.bottomAnchor.constraint(equalTo: iconScrollView.bottomAnchor),
+            iconStackView.leadingAnchor.constraint(equalTo: iconScrollView.leadingAnchor),
+            iconStackView.trailingAnchor.constraint(equalTo: iconScrollView.trailingAnchor),
+            iconStackView.heightAnchor.constraint(equalTo: iconScrollView.heightAnchor),
+        ])
+    }
+
+    private func labeledField(label: String, field: UIView) -> UIStackView {
+        let titleLabel = UILabel()
+        titleLabel.text = label
+        titleLabel.font = Fonts.textSM.font
+        titleLabel.textColor = Colors.gray600
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        let stack = UIStackView(arrangedSubviews: [titleLabel, field])
+        stack.axis = .vertical
+        stack.spacing = Metrics.spacing2
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        return stack
+    }
+
+    // MARK: - Selectors
+
+    private func buildColorSelector() {
+        for index in 0..<AllocationTagPalette.count {
+            let button = UIButton()
+            // The `ink` tone, not `arc`: this form sits on gray100, and the bright ring tones are
+            // built for the dark card.
+            button.backgroundColor = AllocationTagPalette.entry(at: index).ink
+            button.layer.cornerRadius = 16
+            button.clipsToBounds = true
+            button.translatesAutoresizingMaskIntoConstraints = false
+            button.heightAnchor.constraint(equalToConstant: 32).isActive = true
+            button.widthAnchor.constraint(equalToConstant: 32).isActive = true
+            button.tag = index
+            button.accessibilityLabel = AllocationTagPalette.entry(at: index).name
+            button.addTarget(self, action: #selector(colorSelected(_:)), for: .touchUpInside)
+            colorButtons.append(button)
+            colorStackView.addArrangedSubview(button)
+        }
+        refreshColorSelection()
+    }
+
+    private func buildIconSelector() {
+        // Index 0 is the default glyph; the rest map onto `iconAssetNames` by offset.
+        let defaultButton = makeIconButton(
+            image: UIImage(systemName: AllocationTag.defaultSymbolName), tag: 0)
+        iconButtons.append(defaultButton)
+        iconStackView.addArrangedSubview(defaultButton)
+
+        for (offset, assetName) in Self.iconAssetNames.enumerated() {
+            let button = makeIconButton(
+                image: UIImage(named: assetName)?.withRenderingMode(.alwaysTemplate),
+                tag: offset + 1)
+            iconButtons.append(button)
+            iconStackView.addArrangedSubview(button)
+        }
+        refreshIconSelection()
+    }
+
+    private func makeIconButton(image: UIImage?, tag: Int) -> UIButton {
+        let button = UIButton()
+        button.setImage(image, for: .normal)
+        button.tintColor = Colors.gray500
+        button.backgroundColor = Colors.gray200
+        button.layer.cornerRadius = 16
+        button.layer.borderWidth = 1
+        button.layer.borderColor = Colors.gray300.cgColor
+        button.clipsToBounds = true
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.heightAnchor.constraint(equalToConstant: 32).isActive = true
+        button.widthAnchor.constraint(equalToConstant: 32).isActive = true
+        button.tag = tag
+        button.addTarget(self, action: #selector(iconSelected(_:)), for: .touchUpInside)
+        return button
+    }
+
+    @objc private func colorSelected(_ sender: UIButton) {
+        selectedColorIndex = sender.tag
+        refreshColorSelection()
+        delegate?.didChangeColorIndex(selectedColorIndex)
+    }
+
+    @objc private func iconSelected(_ sender: UIButton) {
+        selectedIconAssetName = sender.tag == 0 ? nil : Self.iconAssetNames[sender.tag - 1]
+        refreshIconSelection()
+        delegate?.didChangeIconAssetName(selectedIconAssetName)
+    }
+
+    /// Same 3pt magenta ring the credit-card colour row uses, so selection reads identically.
+    private func refreshColorSelection() {
+        for button in colorButtons {
+            let isSelected = button.tag == selectedColorIndex
+            button.layer.borderWidth = isSelected ? 3 : 0
+            button.layer.borderColor = isSelected ? Colors.mainMagenta.cgColor : nil
+        }
+    }
+
+    private func refreshIconSelection() {
+        let selectedTag =
+            selectedIconAssetName.flatMap { Self.iconAssetNames.firstIndex(of: $0).map { $0 + 1 } } ?? 0
+        for button in iconButtons {
+            let isSelected = button.tag == selectedTag
+            button.layer.borderWidth = isSelected ? 3 : 1
+            button.layer.borderColor =
+                isSelected ? Colors.mainMagenta.cgColor : Colors.gray300.cgColor
+            button.tintColor = isSelected ? Colors.mainMagenta : Colors.gray500
+        }
+    }
+
+    // MARK: - Configuration
+
+    func configure(with tag: AllocationTag, categoryCount: Int) {
+        nameInput.textField.text = tag.name
+        selectedColorIndex = AllocationTagPalette.clampIndex(tag.colorIndex)
+        selectedIconAssetName = tag.iconAssetName
+        refreshColorSelection()
+        refreshIconSelection()
+        updateCategoryCount(categoryCount)
+    }
+
+    func updateCategoryCount(_ count: Int) {
+        categoryCountLabel.text = "\(count)"
+    }
+
+    @objc private func backTapped() { delegate?.didTapBackButton() }
+    @objc private func deleteTapped() { delegate?.didTapDeleteTag() }
+    @objc private func categoriesTapped() { delegate?.didTapCategories() }
+    @objc private func nameChanged() {
+        delegate?.didChangeName(nameInput.textField.text ?? "")
+    }
+}

--- a/Finova/Sources/Scenes/AllocationTags/AllocationTagEditViewController.swift
+++ b/Finova/Sources/Scenes/AllocationTags/AllocationTagEditViewController.swift
@@ -1,0 +1,140 @@
+//
+//  AllocationTagEditViewController.swift
+//  Finova
+//
+//  Created by Arthur Rios on 04/08/26.
+//
+
+import UIKit
+
+protocol AllocationTagEditViewDelegate: AnyObject {
+    func didTapBackButton()
+    func didChangeName(_ name: String)
+    func didChangeColorIndex(_ index: Int)
+    func didChangeIconAssetName(_ assetName: String?)
+    func didTapCategories()
+    func didTapDeleteTag()
+}
+
+final class AllocationTagEditViewController: UIViewController {
+
+    let contentView: AllocationTagEditView
+    private let tagService: AllocationTagService
+    private var tag: AllocationTag
+    weak var flowDelegate: AllocationTagEditFlowDelegate?
+
+    init(
+        contentView: AllocationTagEditView,
+        tag: AllocationTag,
+        tagService: AllocationTagService = .shared,
+        flowDelegate: AllocationTagEditFlowDelegate
+    ) {
+        self.contentView = contentView
+        self.tag = tag
+        self.tagService = tagService
+        self.flowDelegate = flowDelegate
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupContentViewToBounds(contentView: contentView, respectingSafeArea: false)
+        contentView.delegate = self
+        refreshFromStore()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        // The category screen writes through the service, so the count here is stale on return.
+        refreshFromStore()
+    }
+
+    /// Colour and icon commit on tap, so the view is always redrawn from what was actually stored
+    /// rather than from an optimistic local copy.
+    private func refreshFromStore() {
+        if let fresh = tagService.tag(id: tag.id) {
+            tag = fresh
+        }
+        contentView.configure(
+            with: tag, categoryCount: tagService.categoryCount(forTagId: tag.id))
+    }
+
+    /// The name is the one field that is typed rather than tapped, so it commits on the way out
+    /// instead of on every keystroke - one write per edit, not one per character.
+    private func commitNameIfNeeded() {
+        let typed = (contentView.nameInput.textField.text ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !typed.isEmpty, typed != tag.name else { return }
+        tagService.rename(tagId: tag.id, to: typed)
+    }
+
+    private func showNameRequiredAlert() {
+        let alert = UIAlertController(
+            title: "allocationTags.edit.error.name.title".localized,
+            message: "allocationTags.edit.error.name.message".localized,
+            preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "alert.ok".localized, style: .default))
+        present(alert, animated: true)
+    }
+
+    private func confirmDelete() {
+        let alert = UIAlertController(
+            title: "allocationTags.delete.title".localized,
+            message: "allocationTags.delete.message".localized,
+            preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "alert.cancel".localized, style: .cancel))
+        alert.addAction(
+            UIAlertAction(title: "allocationTags.delete.confirm".localized, style: .destructive) {
+                [weak self] _ in
+                guard let self else { return }
+                self.tagService.deleteTag(id: self.tag.id)
+                self.flowDelegate?.dismissAllocationTagEdit()
+            })
+        present(alert, animated: true)
+    }
+}
+
+// MARK: - AllocationTagEditViewDelegate
+
+extension AllocationTagEditViewController: AllocationTagEditViewDelegate {
+
+    func didTapBackButton() {
+        let typed = (contentView.nameInput.textField.text ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !typed.isEmpty else {
+            // Refuse to leave a tag with a blank name rather than silently keeping the old one - the
+            // user cleared the field on purpose and deserves to know it was not saved.
+            showNameRequiredAlert()
+            return
+        }
+        commitNameIfNeeded()
+        flowDelegate?.dismissAllocationTagEdit()
+    }
+
+    func didChangeName(_ name: String) {
+        // Committed on exit; nothing to do per keystroke.
+    }
+
+    func didChangeColorIndex(_ index: Int) {
+        tagService.setColorIndex(index, forTagId: tag.id)
+        refreshFromStore()
+    }
+
+    func didChangeIconAssetName(_ assetName: String?) {
+        tagService.setIconAssetName(assetName, forTagId: tag.id)
+        refreshFromStore()
+    }
+
+    func didTapCategories() {
+        commitNameIfNeeded()
+        flowDelegate?.navigateToAllocationTagCategories(tag: tag)
+    }
+
+    func didTapDeleteTag() {
+        confirmDelete()
+    }
+}

--- a/Finova/Sources/Scenes/AllocationTags/AllocationTagsFlowDelegate.swift
+++ b/Finova/Sources/Scenes/AllocationTags/AllocationTagsFlowDelegate.swift
@@ -1,0 +1,24 @@
+//
+//  AllocationTagsFlowDelegate.swift
+//  Finova
+//
+//  Created by Arthur Rios on 04/08/26.
+//
+
+import Foundation
+
+protocol AllocationTagsFlowDelegate: AnyObject {
+    func dismissAllocationTags()
+    /// Pushed straight after creating a tag too: a tag with no categories does nothing, so the edit
+    /// screen is where the work actually happens.
+    func navigateToAllocationTagEdit(tag: AllocationTag)
+}
+
+protocol AllocationTagEditFlowDelegate: AnyObject {
+    func dismissAllocationTagEdit()
+    func navigateToAllocationTagCategories(tag: AllocationTag)
+}
+
+protocol AllocationTagCategoriesFlowDelegate: AnyObject {
+    func dismissAllocationTagCategories()
+}

--- a/Finova/Sources/Scenes/AllocationTags/AllocationTagsView.swift
+++ b/Finova/Sources/Scenes/AllocationTags/AllocationTagsView.swift
@@ -1,0 +1,299 @@
+//
+//  AllocationTagsView.swift
+//  Finova
+//
+//  Created by Arthur Rios on 04/08/26.
+//
+
+import UIKit
+
+final class AllocationTagsView: UIView {
+
+    weak var delegate: AllocationTagsViewDelegate?
+
+    // MARK: - Header
+
+    private let headerContainerView: UIView = {
+        let view = UIView()
+        view.backgroundColor = Colors.gray100
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.heightAnchor.constraint(equalToConstant: Metrics.headerHeight).isActive = true
+        return view
+    }()
+
+    private let headerItemsView: UIView = {
+        let view = UIView()
+        view.directionalLayoutMargins = NSDirectionalEdgeInsets(
+            top: Metrics.spacing4, leading: Metrics.spacing5, bottom: Metrics.spacing5,
+            trailing: Metrics.spacing5)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private let backButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setImage(UIImage(named: "chevronLeft")?.withRenderingMode(.alwaysTemplate), for: .normal)
+        button.imageView?.contentMode = .scaleAspectFit
+        button.translatesAutoresizingMaskIntoConstraints = false
+        if #available(iOS 26.0, *) {
+            button.tintColor = Colors.gray700
+        } else {
+            button.tintColor = Colors.gray500
+        }
+        return button
+    }()
+
+    private lazy var backButtonGlassContainer: UIView = {
+        let container = UIView()
+        container.translatesAutoresizingMaskIntoConstraints = false
+        return container
+    }()
+
+    private let headerTitleLabel: UILabel = {
+        let label = UILabel()
+        label.fontStyle = Fonts.titleSM
+        label.text = "allocationTags.title".localized
+        label.applyStyle()
+        label.textColor = Colors.gray700
+        label.textAlignment = .left
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private let headerSubtitleLabel: UILabel = {
+        let label = UILabel()
+        label.font = Fonts.textSM.font
+        label.text = "allocationTags.subtitle".localized
+        label.textColor = Colors.gray500
+        label.textAlignment = .left
+        label.numberOfLines = 2
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private lazy var headerTextStackView = UIStackView(
+        axis: .vertical, spacing: Metrics.spacing1,
+        arrangedSubviews: [headerTitleLabel, headerSubtitleLabel])
+
+    // MARK: - Content
+
+    let tableView: UITableView = {
+        let table = UITableView(frame: .zero, style: .plain)
+        table.backgroundColor = .clear
+        table.separatorStyle = .none
+        table.showsVerticalScrollIndicator = false
+        table.translatesAutoresizingMaskIntoConstraints = false
+        return table
+    }()
+
+    private let emptyStateIconView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = UIImage(systemName: "tag")
+        imageView.tintColor = Colors.gray400
+        imageView.contentMode = .scaleAspectFit
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        return imageView
+    }()
+
+    private let emptyStateLabel: UILabel = {
+        let label = UILabel()
+        label.font = Fonts.textSM.font
+        label.text = "allocationTags.emptyState.description".localized
+        label.textColor = Colors.gray400
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private lazy var emptyStateView: UIView = {
+        let view = UIView()
+        view.isHidden = true
+        view.translatesAutoresizingMaskIntoConstraints = false
+
+        let stack = UIStackView(
+            axis: .vertical, spacing: Metrics.spacing3, alignment: .center,
+            arrangedSubviews: [emptyStateIconView, emptyStateLabel])
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(stack)
+
+        NSLayoutConstraint.activate([
+            emptyStateIconView.widthAnchor.constraint(equalToConstant: 48),
+            emptyStateIconView.heightAnchor.constraint(equalToConstant: 48),
+
+            stack.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            stack.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            stack.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Metrics.spacing8),
+            stack.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -Metrics.spacing8),
+        ])
+        return view
+    }()
+
+    // FAB, matching the BudgetGroups create button.
+    private let createTagButton: UIButton = {
+        let button = UIButton(type: .system)
+
+        if let original = UIImage(named: "plus") {
+            let size = CGSize(width: 24, height: 24)
+            UIGraphicsBeginImageContextWithOptions(size, false, 0.0)
+            original.draw(in: CGRect(origin: .zero, size: size))
+            let resized = UIGraphicsGetImageFromCurrentImageContext()
+            UIGraphicsEndImageContext()
+            button.setImage(resized, for: .normal)
+        }
+
+        button.imageView?.contentMode = .center
+        button.translatesAutoresizingMaskIntoConstraints = false
+
+        if #available(iOS 26.0, *) {
+            button.tintColor = Colors.mainMagenta
+            button.backgroundColor = .clear
+        } else {
+            button.tintColor = Colors.gray100
+            button.backgroundColor = Colors.gray700
+            button.layer.shadowColor = UIColor.black.cgColor
+            button.layer.shadowOffset = CGSize(width: 0, height: 4)
+            button.layer.shadowOpacity = 0.25
+            button.layer.shadowRadius = 4
+            button.layer.shouldRasterize = true
+            button.layer.rasterizationScale = UIScreen.main.scale
+        }
+        return button
+    }()
+
+    private lazy var createTagButtonGlassContainer: UIView = {
+        let container = UIView()
+        container.translatesAutoresizingMaskIntoConstraints = false
+        return container
+    }()
+
+    // MARK: - Init
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = Colors.gray200
+        setupView()
+        setupLayout()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupView() {
+        addSubview(headerContainerView)
+        headerContainerView.addSubview(headerItemsView)
+        headerItemsView.addSubview(backButtonGlassContainer)
+        backButtonGlassContainer.addSubview(backButton)
+        headerItemsView.addSubview(headerTextStackView)
+        headerTextStackView.translatesAutoresizingMaskIntoConstraints = false
+
+        addSubview(tableView)
+        addSubview(emptyStateView)
+        addSubview(createTagButtonGlassContainer)
+        createTagButtonGlassContainer.addSubview(createTagButton)
+
+        if #available(iOS 26.0, *) {
+            let backGlass = UIGlassEffect(style: .clear)
+            backGlass.isInteractive = true
+            let backGlassView = UIVisualEffectView(effect: backGlass)
+            backGlassView.translatesAutoresizingMaskIntoConstraints = false
+            backButtonGlassContainer.insertSubview(backGlassView, at: 0)
+            backGlassView.pinToSuperview()
+            backButtonGlassContainer.layer.cornerRadius = 18
+            backButtonGlassContainer.clipsToBounds = true
+
+            let fabGlass = UIGlassEffect(style: .clear)
+            fabGlass.isInteractive = true
+            let fabGlassView = UIVisualEffectView(effect: fabGlass)
+            fabGlassView.translatesAutoresizingMaskIntoConstraints = false
+            createTagButtonGlassContainer.insertSubview(fabGlassView, at: 0)
+            fabGlassView.pinToSuperview()
+        }
+
+        backButton.addTarget(self, action: #selector(backTapped), for: .touchUpInside)
+        createTagButton.addTarget(self, action: #selector(createTagTapped), for: .touchUpInside)
+    }
+
+    private func setupLayout() {
+        NSLayoutConstraint.activate([
+            headerContainerView.topAnchor.constraint(equalTo: topAnchor),
+            headerContainerView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            headerContainerView.trailingAnchor.constraint(equalTo: trailingAnchor),
+
+            headerItemsView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
+            headerItemsView.leadingAnchor.constraint(equalTo: headerContainerView.leadingAnchor),
+            headerItemsView.trailingAnchor.constraint(equalTo: headerContainerView.trailingAnchor),
+            headerItemsView.bottomAnchor.constraint(equalTo: headerContainerView.bottomAnchor),
+
+            backButtonGlassContainer.topAnchor.constraint(
+                equalTo: headerItemsView.layoutMarginsGuide.topAnchor),
+            backButtonGlassContainer.leadingAnchor.constraint(
+                equalTo: headerItemsView.layoutMarginsGuide.leadingAnchor),
+            backButtonGlassContainer.widthAnchor.constraint(equalToConstant: 36),
+            backButtonGlassContainer.heightAnchor.constraint(equalToConstant: 36),
+
+            backButton.topAnchor.constraint(equalTo: backButtonGlassContainer.topAnchor),
+            backButton.leadingAnchor.constraint(equalTo: backButtonGlassContainer.leadingAnchor),
+            backButton.trailingAnchor.constraint(equalTo: backButtonGlassContainer.trailingAnchor),
+            backButton.bottomAnchor.constraint(equalTo: backButtonGlassContainer.bottomAnchor),
+
+            headerTextStackView.leadingAnchor.constraint(
+                equalTo: backButtonGlassContainer.trailingAnchor, constant: Metrics.spacing4),
+            headerTextStackView.centerYAnchor.constraint(
+                equalTo: backButtonGlassContainer.centerYAnchor),
+            headerTextStackView.trailingAnchor.constraint(
+                lessThanOrEqualTo: headerItemsView.layoutMarginsGuide.trailingAnchor),
+
+            tableView.topAnchor.constraint(
+                equalTo: headerContainerView.bottomAnchor, constant: Metrics.spacing4),
+            tableView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Metrics.spacing4),
+            tableView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Metrics.spacing4),
+            tableView.bottomAnchor.constraint(equalTo: bottomAnchor),
+
+            emptyStateView.topAnchor.constraint(equalTo: tableView.topAnchor),
+            emptyStateView.leadingAnchor.constraint(equalTo: tableView.leadingAnchor),
+            emptyStateView.trailingAnchor.constraint(equalTo: tableView.trailingAnchor),
+            emptyStateView.bottomAnchor.constraint(
+                equalTo: createTagButtonGlassContainer.topAnchor, constant: -Metrics.spacing4),
+
+            createTagButtonGlassContainer.centerXAnchor.constraint(equalTo: centerXAnchor),
+            createTagButtonGlassContainer.bottomAnchor.constraint(
+                equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -Metrics.spacing4),
+            createTagButtonGlassContainer.widthAnchor.constraint(
+                equalToConstant: Metrics.addButtonSize),
+            createTagButtonGlassContainer.heightAnchor.constraint(
+                equalToConstant: Metrics.addButtonSize),
+
+            createTagButton.topAnchor.constraint(equalTo: createTagButtonGlassContainer.topAnchor),
+            createTagButton.leadingAnchor.constraint(
+                equalTo: createTagButtonGlassContainer.leadingAnchor),
+            createTagButton.trailingAnchor.constraint(
+                equalTo: createTagButtonGlassContainer.trailingAnchor),
+            createTagButton.bottomAnchor.constraint(
+                equalTo: createTagButtonGlassContainer.bottomAnchor),
+        ])
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        let radius = createTagButtonGlassContainer.bounds.height / 2
+        createTagButtonGlassContainer.layer.cornerRadius = radius
+        createTagButtonGlassContainer.clipsToBounds = true
+
+        if #unavailable(iOS 26.0) {
+            createTagButton.layer.cornerRadius = radius
+            createTagButton.layer.shadowPath = UIBezierPath(
+                roundedRect: createTagButton.bounds, cornerRadius: radius).cgPath
+        }
+    }
+
+    func updateEmptyState(isEmpty: Bool) {
+        emptyStateView.isHidden = !isEmpty
+        tableView.isHidden = isEmpty
+    }
+
+    @objc private func backTapped() { delegate?.didTapBackButton() }
+    @objc private func createTagTapped() { delegate?.didTapCreateTag() }
+}

--- a/Finova/Sources/Scenes/AllocationTags/AllocationTagsViewController.swift
+++ b/Finova/Sources/Scenes/AllocationTags/AllocationTagsViewController.swift
@@ -60,33 +60,12 @@ final class AllocationTagsViewController: UIViewController {
     }
 
     private func showCreateTagAlert() {
-        let alert = UIAlertController(
-            title: "allocationTags.create.title".localized,
-            message: "allocationTags.create.message".localized,
-            preferredStyle: .alert)
-
-        alert.addTextField { textField in
-            textField.placeholder = "allocationTags.create.namePlaceholder".localized
-            textField.autocapitalizationType = .words
-        }
-
-        let createAction = UIAlertAction(
-            title: "allocationTags.create.button".localized, style: .default
-        ) { [weak self, weak alert] _ in
-            guard
-                let name = alert?.textFields?.first?.text?
-                    .trimmingCharacters(in: .whitespacesAndNewlines),
-                !name.isEmpty,
-                let tag = self?.viewModel.createTag(name: name)
-            else { return }
+        AllocationTagCreationPrompt.present(from: self) { [weak self] tag in
+            guard let self else { return }
+            self.viewModel.loadTags()
             // Straight into editing: a tag with no categories has no effect on anything.
-            self?.flowDelegate?.navigateToAllocationTagEdit(tag: tag)
+            self.flowDelegate?.navigateToAllocationTagEdit(tag: tag)
         }
-
-        alert.addAction(createAction)
-        alert.addAction(UIAlertAction(title: "alert.cancel".localized, style: .cancel))
-
-        present(alert, animated: true)
     }
 
     private func confirmDelete(at index: Int, completion: @escaping (Bool) -> Void) {

--- a/Finova/Sources/Scenes/AllocationTags/AllocationTagsViewController.swift
+++ b/Finova/Sources/Scenes/AllocationTags/AllocationTagsViewController.swift
@@ -1,0 +1,162 @@
+//
+//  AllocationTagsViewController.swift
+//  Finova
+//
+//  Created by Arthur Rios on 04/08/26.
+//
+
+import UIKit
+
+final class AllocationTagsViewController: UIViewController {
+
+    let contentView: AllocationTagsView
+    private let viewModel: AllocationTagsViewModel
+    weak var flowDelegate: AllocationTagsFlowDelegate?
+
+    init(
+        contentView: AllocationTagsView,
+        viewModel: AllocationTagsViewModel,
+        flowDelegate: AllocationTagsFlowDelegate
+    ) {
+        self.contentView = contentView
+        self.viewModel = viewModel
+        self.flowDelegate = flowDelegate
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupContentViewToBounds(contentView: contentView, respectingSafeArea: false)
+        contentView.delegate = self
+        setupTableView()
+        bindViewModel()
+        viewModel.loadTags()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        // Category links and names change on the pushed screens, so the counts here are stale on
+        // every return.
+        viewModel.loadTags()
+    }
+
+    private func setupTableView() {
+        contentView.tableView.delegate = self
+        contentView.tableView.dataSource = self
+        contentView.tableView.register(
+            AllocationTagCell.self, forCellReuseIdentifier: AllocationTagCell.identifier)
+    }
+
+    private func bindViewModel() {
+        viewModel.onTagsUpdated = { [weak self] in
+            guard let self else { return }
+            self.contentView.tableView.reloadData()
+            self.contentView.updateEmptyState(isEmpty: self.viewModel.isEmpty)
+        }
+    }
+
+    private func showCreateTagAlert() {
+        let alert = UIAlertController(
+            title: "allocationTags.create.title".localized,
+            message: "allocationTags.create.message".localized,
+            preferredStyle: .alert)
+
+        alert.addTextField { textField in
+            textField.placeholder = "allocationTags.create.namePlaceholder".localized
+            textField.autocapitalizationType = .words
+        }
+
+        let createAction = UIAlertAction(
+            title: "allocationTags.create.button".localized, style: .default
+        ) { [weak self, weak alert] _ in
+            guard
+                let name = alert?.textFields?.first?.text?
+                    .trimmingCharacters(in: .whitespacesAndNewlines),
+                !name.isEmpty,
+                let tag = self?.viewModel.createTag(name: name)
+            else { return }
+            // Straight into editing: a tag with no categories has no effect on anything.
+            self?.flowDelegate?.navigateToAllocationTagEdit(tag: tag)
+        }
+
+        alert.addAction(createAction)
+        alert.addAction(UIAlertAction(title: "alert.cancel".localized, style: .cancel))
+
+        present(alert, animated: true)
+    }
+
+    private func confirmDelete(at index: Int, completion: @escaping (Bool) -> Void) {
+        let alert = UIAlertController(
+            title: "allocationTags.delete.title".localized,
+            // Spelled out because nobody assumes it: deleting a lens must not read as deleting the
+            // money behind it.
+            message: "allocationTags.delete.message".localized,
+            preferredStyle: .alert)
+
+        alert.addAction(
+            UIAlertAction(title: "alert.cancel".localized, style: .cancel) { _ in
+                completion(false)
+            })
+        alert.addAction(
+            UIAlertAction(title: "allocationTags.delete.confirm".localized, style: .destructive) {
+                [weak self] _ in
+                self?.viewModel.deleteTag(at: index)
+                completion(true)
+            })
+
+        present(alert, animated: true)
+    }
+}
+
+// MARK: - AllocationTagsViewDelegate
+
+extension AllocationTagsViewController: AllocationTagsViewDelegate {
+    func didTapBackButton() {
+        flowDelegate?.dismissAllocationTags()
+    }
+
+    func didTapCreateTag() {
+        showCreateTagAlert()
+    }
+}
+
+// MARK: - UITableViewDataSource & UITableViewDelegate
+
+extension AllocationTagsViewController: UITableViewDataSource, UITableViewDelegate {
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        viewModel.tags.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard
+            let cell = tableView.dequeueReusableCell(
+                withIdentifier: AllocationTagCell.identifier, for: indexPath) as? AllocationTagCell
+        else {
+            return UITableViewCell()
+        }
+        let tag = viewModel.tags[indexPath.row]
+        cell.configure(with: tag, categoryCount: viewModel.categoryCount(for: tag))
+        return cell
+    }
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        flowDelegate?.navigateToAllocationTagEdit(tag: viewModel.tags[indexPath.row])
+    }
+
+    func tableView(
+        _ tableView: UITableView,
+        trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath
+    ) -> UISwipeActionsConfiguration? {
+        let deleteAction = UIContextualAction(
+            style: .destructive, title: "alert.delete".localized
+        ) { [weak self] _, _, completionHandler in
+            self?.confirmDelete(at: indexPath.row, completion: completionHandler)
+        }
+        return UISwipeActionsConfiguration(actions: [deleteAction])
+    }
+}

--- a/Finova/Sources/Scenes/AllocationTags/AllocationTagsViewDelegate.swift
+++ b/Finova/Sources/Scenes/AllocationTags/AllocationTagsViewDelegate.swift
@@ -1,0 +1,13 @@
+//
+//  AllocationTagsViewDelegate.swift
+//  Finova
+//
+//  Created by Arthur Rios on 04/08/26.
+//
+
+import Foundation
+
+protocol AllocationTagsViewDelegate: AnyObject {
+    func didTapBackButton()
+    func didTapCreateTag()
+}

--- a/Finova/Sources/Scenes/AllocationTags/AllocationTagsViewModel.swift
+++ b/Finova/Sources/Scenes/AllocationTags/AllocationTagsViewModel.swift
@@ -1,0 +1,45 @@
+//
+//  AllocationTagsViewModel.swift
+//  Finova
+//
+//  Created by Arthur Rios on 04/08/26.
+//
+
+import Foundation
+
+final class AllocationTagsViewModel {
+
+    private let tagService: AllocationTagService
+
+    private(set) var tags: [AllocationTag] = []
+
+    var onTagsUpdated: (() -> Void)?
+
+    var isEmpty: Bool { tags.isEmpty }
+
+    init(tagService: AllocationTagService = .shared) {
+        self.tagService = tagService
+    }
+
+    func loadTags() {
+        tags = tagService.tags
+        onTagsUpdated?()
+    }
+
+    func categoryCount(for tag: AllocationTag) -> Int {
+        tagService.categoryCount(forTagId: tag.id)
+    }
+
+    /// Returns the created tag so the caller can push straight into editing it.
+    func createTag(name: String) -> AllocationTag? {
+        let tag = tagService.createTag(name: name)
+        loadTags()
+        return tag
+    }
+
+    func deleteTag(at index: Int) {
+        guard tags.indices.contains(index) else { return }
+        tagService.deleteTag(id: tags[index].id)
+        loadTags()
+    }
+}

--- a/Finova/Sources/Scenes/AllocationTags/Views/AllocationTagCell.swift
+++ b/Finova/Sources/Scenes/AllocationTags/Views/AllocationTagCell.swift
@@ -1,0 +1,148 @@
+//
+//  AllocationTagCell.swift
+//  Finova
+//
+//  Created by Arthur Rios on 04/08/26.
+//
+
+import UIKit
+
+/// One tag in the management list. Same card-row shape as `BudgetGroupCell`, with the tag's own colour
+/// standing in for that cell's fixed magenta.
+final class AllocationTagCell: UITableViewCell {
+
+    static let identifier = "AllocationTagCell"
+
+    private let containerView: UIView = {
+        let view = UIView()
+        view.backgroundColor = Colors.gray100
+        view.layer.cornerRadius = CornerRadius.large
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    /// A tinted disc behind the glyph, so the tag's colour is legible at a glance even when the icon
+    /// is the generic default and every row would otherwise look alike.
+    private let iconContainer: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private let iconView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFit
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        return imageView
+    }()
+
+    private let nameLabel: UILabel = {
+        let label = UILabel()
+        label.font = Fonts.titleSM.font
+        label.textColor = Colors.gray700
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private let categoryCountLabel: UILabel = {
+        let label = UILabel()
+        label.font = Fonts.textXS.font
+        label.textColor = Colors.gray500
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private let chevronView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = UIImage(systemName: "chevron.right")
+        imageView.tintColor = Colors.gray400
+        imageView.contentMode = .scaleAspectFit
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        return imageView
+    }()
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        selectionStyle = .none
+        backgroundColor = .clear
+        contentView.backgroundColor = .clear
+        setupView()
+        setupLayout()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupView() {
+        contentView.addSubview(containerView)
+        containerView.addSubview(iconContainer)
+        iconContainer.addSubview(iconView)
+        containerView.addSubview(nameLabel)
+        containerView.addSubview(categoryCountLabel)
+        containerView.addSubview(chevronView)
+    }
+
+    private func setupLayout() {
+        NSLayoutConstraint.activate([
+            containerView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: Metrics.spacing1),
+            containerView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            containerView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            containerView.bottomAnchor.constraint(
+                equalTo: contentView.bottomAnchor, constant: -Metrics.spacing1),
+            containerView.heightAnchor.constraint(greaterThanOrEqualToConstant: 64),
+
+            iconContainer.leadingAnchor.constraint(
+                equalTo: containerView.leadingAnchor, constant: Metrics.spacing4),
+            iconContainer.centerYAnchor.constraint(equalTo: containerView.centerYAnchor),
+            iconContainer.widthAnchor.constraint(equalToConstant: 32),
+            iconContainer.heightAnchor.constraint(equalToConstant: 32),
+
+            iconView.centerXAnchor.constraint(equalTo: iconContainer.centerXAnchor),
+            iconView.centerYAnchor.constraint(equalTo: iconContainer.centerYAnchor),
+            iconView.widthAnchor.constraint(equalToConstant: Metrics.inputIconSize),
+            iconView.heightAnchor.constraint(equalToConstant: Metrics.inputIconSize),
+
+            nameLabel.leadingAnchor.constraint(
+                equalTo: iconContainer.trailingAnchor, constant: Metrics.spacing3),
+            nameLabel.topAnchor.constraint(equalTo: containerView.topAnchor, constant: Metrics.spacing3),
+            nameLabel.trailingAnchor.constraint(
+                lessThanOrEqualTo: chevronView.leadingAnchor, constant: -Metrics.spacing3),
+
+            categoryCountLabel.leadingAnchor.constraint(equalTo: nameLabel.leadingAnchor),
+            categoryCountLabel.topAnchor.constraint(equalTo: nameLabel.bottomAnchor, constant: 2),
+            categoryCountLabel.trailingAnchor.constraint(
+                lessThanOrEqualTo: chevronView.leadingAnchor, constant: -Metrics.spacing3),
+
+            chevronView.trailingAnchor.constraint(
+                equalTo: containerView.trailingAnchor, constant: -Metrics.spacing4),
+            chevronView.centerYAnchor.constraint(equalTo: containerView.centerYAnchor),
+            chevronView.widthAnchor.constraint(equalToConstant: 12),
+            chevronView.heightAnchor.constraint(equalToConstant: 12),
+        ])
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        iconContainer.layer.cornerRadius = iconContainer.bounds.height / 2
+    }
+
+    func configure(with tag: AllocationTag, categoryCount: Int) {
+        let ink = tag.color.ink
+        iconContainer.backgroundColor = ink.withAlphaComponent(0.12)
+        iconView.image = tag.icon.image
+        iconView.tintColor = ink
+
+        nameLabel.text = tag.name
+
+        switch categoryCount {
+        case 0:
+            categoryCountLabel.text = "allocationTags.row.noCategories".localized
+        case 1:
+            categoryCountLabel.text = "allocationTags.row.categoryCount.one".localized
+        default:
+            categoryCountLabel.text = String(
+                format: "allocationTags.row.categoryCount".localized, categoryCount)
+        }
+    }
+}

--- a/Finova/Sources/Scenes/Budgets/BudgetsFlowDelegate.swift
+++ b/Finova/Sources/Scenes/Budgets/BudgetsFlowDelegate.swift
@@ -9,4 +9,5 @@ import Foundation
 
 public protocol BudgetsFlowDelegate: AnyObject {
     func navBackToDashboard()
+    func navigateToAllocationTags()
 }

--- a/Finova/Sources/Scenes/Budgets/BudgetsView.swift
+++ b/Finova/Sources/Scenes/Budgets/BudgetsView.swift
@@ -115,6 +115,19 @@ final class BudgetsView: UIView {
     
     private let budgetsTableHeaderView = CardHeader(
         headerTitle: "budgets.table.header.title".localized)
+
+    /// Entry point to allocation tags. Overlaid on the header rather than added to its stack:
+    /// `CardHeader`'s stack is `.equalSpacing` and shared by several screens, so a third arranged
+    /// subview would redistribute the spacing everywhere it is used. The header's trailing side is
+    /// free here because no items-quantity pill is passed.
+    private let manageTagsButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("budgets.tags.manage".localized, for: .normal)
+        button.titleLabel?.font = Fonts.titleXS.font
+        button.setTitleColor(Colors.mainMagenta, for: .normal)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
     
     let budgetsTableView: UITableView = {
         let tableView = UITableView()
@@ -207,6 +220,7 @@ final class BudgetsView: UIView {
         cardContentView.addSubview(addButton)
         
         addSubview(budgetsTableHeaderView)
+        budgetsTableHeaderView.addSubview(manageTagsButton)
         addSubview(budgetsTableView)
         
         addSubview(emptyStateView)
@@ -215,6 +229,7 @@ final class BudgetsView: UIView {
         
         backButton.addTarget(self, action: #selector(didTapBackButton), for: .touchUpInside)
         addButton.addTarget(self, action: #selector(didTapAddBudgetButton), for: .touchUpInside)
+        manageTagsButton.addTarget(self, action: #selector(didTapManageTags), for: .touchUpInside)
         
         setupConstraints()
     }
@@ -261,6 +276,10 @@ final class BudgetsView: UIView {
             budgetsTableHeaderView.leadingAnchor.constraint(equalTo: cardContentView.leadingAnchor),
             budgetsTableHeaderView.trailingAnchor.constraint(equalTo: cardContentView.trailingAnchor),
             
+            manageTagsButton.trailingAnchor.constraint(
+                equalTo: budgetsTableHeaderView.trailingAnchor, constant: -Metrics.spacing4),
+            manageTagsButton.centerYAnchor.constraint(equalTo: budgetsTableHeaderView.centerYAnchor),
+
             budgetsTableView.topAnchor.constraint(equalTo: budgetsTableHeaderView.bottomAnchor),
             budgetsTableView.leadingAnchor.constraint(equalTo: cardContentView.leadingAnchor),
             budgetsTableView.trailingAnchor.constraint(equalTo: cardContentView.trailingAnchor),
@@ -336,6 +355,11 @@ final class BudgetsView: UIView {
     @objc
     private func didTapBackButton() {
         delegate?.didTapBackButton()
+    }
+
+    @objc
+    private func didTapManageTags() {
+        delegate?.didTapManageTags()
     }
     
     @objc

--- a/Finova/Sources/Scenes/Budgets/BudgetsViewController.swift
+++ b/Finova/Sources/Scenes/Budgets/BudgetsViewController.swift
@@ -185,6 +185,10 @@ extension BudgetsViewController: BudgetsViewDelegate {
     func didTapBackButton() {
         flowDelegate?.navBackToDashboard()
     }
+
+    func didTapManageTags() {
+        flowDelegate?.navigateToAllocationTags()
+    }
 }
 
 extension BudgetsViewController: UITableViewDataSource, UITableViewDelegate, BudgetsCellDelegate {

--- a/Finova/Sources/Scenes/Budgets/BudgetsViewDelegate.swift
+++ b/Finova/Sources/Scenes/Budgets/BudgetsViewDelegate.swift
@@ -10,4 +10,5 @@ import Foundation
 public protocol BudgetsViewDelegate: AnyObject {
     func didTapAddBudgetButton(monthYearDate: String, budgetAmount: Int)
     func didTapBackButton()
+    func didTapManageTags()
 }

--- a/Finova/Sources/Scenes/Dashboard/DashboardCarousel/MonthCarousel/BudgetCard/AllocationTagStripView.swift
+++ b/Finova/Sources/Scenes/Dashboard/DashboardCarousel/MonthCarousel/BudgetCard/AllocationTagStripView.swift
@@ -10,6 +10,7 @@ import UIKit
 protocol AllocationTagStripViewDelegate: AnyObject {
     /// `nil` clears the filter.
     func didSelectTag(_ tagId: String?)
+    func didTapCreateTag()
 }
 
 /// The per-tag subtotals under the budget card, doubling as the filter control for the list below.
@@ -153,6 +154,10 @@ final class AllocationTagStripView: UIView {
             chipsStackView.addArrangedSubview(chip.button)
         }
 
+        // Trailing, after Untagged: creating a tag is the least frequent thing done here, so it goes
+        // last, past the figures the strip exists to show.
+        chipsStackView.addArrangedSubview(makeAddChip())
+
         updateClearChip()
         refreshSelection()
         return true
@@ -208,6 +213,28 @@ final class AllocationTagStripView: UIView {
         return Chip(
             button: chip, dot: dot, nameLabel: nameLabel, amountLabel: amountLabel,
             inkColor: inkColor)
+    }
+
+    /// Magenta rather than a palette colour: this is an app action, not a tag, and `mainMagenta` is
+    /// what the app already uses for "add" affordances.
+    private func makeAddChip() -> UIButton {
+        let chip = UIButton(type: .system)
+        chip.translatesAutoresizingMaskIntoConstraints = false
+        chip.backgroundColor = Colors.lowMagenta
+        chip.layer.borderWidth = 1
+        chip.layer.borderColor = Colors.mainMagenta.cgColor
+        chip.layer.cornerRadius = Self.chipHeight / 2
+        chip.setImage(
+            UIImage(
+                systemName: "plus",
+                withConfiguration: UIImage.SymbolConfiguration(pointSize: 12, weight: .semibold)),
+            for: .normal)
+        chip.tintColor = Colors.mainMagenta
+        chip.accessibilityLabel = "allocationTags.create.title".localized
+        chip.heightAnchor.constraint(equalToConstant: Self.chipHeight).isActive = true
+        chip.widthAnchor.constraint(equalToConstant: Self.chipHeight).isActive = true
+        chip.addTarget(self, action: #selector(addTapped), for: .touchUpInside)
+        return chip
     }
 
     private func makeClearChip() -> UIButton {
@@ -325,5 +352,9 @@ final class AllocationTagStripView: UIView {
 
     @objc private func clearTapped() {
         delegate?.didSelectTag(nil)
+    }
+
+    @objc private func addTapped() {
+        delegate?.didTapCreateTag()
     }
 }

--- a/Finova/Sources/Scenes/Dashboard/DashboardCarousel/MonthCarousel/BudgetCard/AllocationTagStripView.swift
+++ b/Finova/Sources/Scenes/Dashboard/DashboardCarousel/MonthCarousel/BudgetCard/AllocationTagStripView.swift
@@ -1,0 +1,329 @@
+//
+//  AllocationTagStripView.swift
+//  Finova
+//
+//  Created by Arthur Rios on 04/08/26.
+//
+
+import UIKit
+
+protocol AllocationTagStripViewDelegate: AnyObject {
+    /// `nil` clears the filter.
+    func didSelectTag(_ tagId: String?)
+}
+
+/// The per-tag subtotals under the budget card, doubling as the filter control for the list below.
+///
+/// Sits between the allocations header and the table rather than inside either. The header is a
+/// horizontal stack whose 44pt height constraint is activated inline with no stored reference, so it
+/// can never be made taller; and its `.equalSpacing` distribution means a third arranged subview would
+/// redistribute the spacing around the two that are there.
+final class AllocationTagStripView: UIView {
+
+    weak var delegate: AllocationTagStripViewDelegate?
+
+    /// Same 44pt as the header above it, so the two read as one band.
+    static let preferredHeight = Metrics.spacing11
+
+    private static let chipHeight: CGFloat = 28
+
+    /// The pieces of one chip that selection restyles. Held explicitly rather than rediscovered by
+    /// walking `subviews`: inverting the dot to `gray100` on selection would otherwise destroy the only
+    /// record of its tag colour, and deselecting could not restore it.
+    private struct Chip {
+        let button: UIButton
+        let dot: UIView
+        let nameLabel: UILabel
+        let amountLabel: UILabel
+        let inkColor: UIColor
+    }
+
+    private var chipsByTagId: [String: Chip] = [:]
+    private var selectedTagId: String?
+    /// Held so it can be inserted and removed as the filter toggles, without rebuilding every chip.
+    private var clearChip: UIButton?
+
+    private let scrollView: UIScrollView = {
+        let scroll = UIScrollView()
+        scroll.showsHorizontalScrollIndicator = false
+        scroll.backgroundColor = .clear
+        scroll.translatesAutoresizingMaskIntoConstraints = false
+        return scroll
+    }()
+
+    private let chipsStackView: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .horizontal
+        stack.spacing = Metrics.spacing2
+        stack.alignment = .center
+        // `.fill`, never `.fillEqually`: chips are sized by their own content and must be allowed to
+        // overflow into the scroll view rather than being squeezed to share the visible width.
+        stack.distribution = .fill
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        return stack
+    }()
+
+    /// Wanted, unlike a bottom edge: the header above deliberately leaves its own bottom open.
+    private let topDividerView: UIView = {
+        let view = UIView()
+        view.backgroundColor = Colors.gray300
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = Colors.gray100
+        // No corner masking: the header owns the top corners and the table the bottom ones, so this
+        // middle band must stay square for the three of them to read as one rounded card.
+        clipsToBounds = true
+
+        addSubview(topDividerView)
+        addSubview(scrollView)
+        scrollView.addSubview(chipsStackView)
+
+        NSLayoutConstraint.activate([
+            topDividerView.topAnchor.constraint(equalTo: topAnchor),
+            topDividerView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            topDividerView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            topDividerView.heightAnchor.constraint(equalToConstant: 1),
+
+            scrollView.topAnchor.constraint(equalTo: topDividerView.bottomAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: bottomAnchor),
+
+            chipsStackView.topAnchor.constraint(equalTo: scrollView.topAnchor),
+            chipsStackView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
+            chipsStackView.heightAnchor.constraint(equalTo: scrollView.heightAnchor),
+            chipsStackView.leadingAnchor.constraint(
+                equalTo: scrollView.leadingAnchor, constant: Metrics.spacing5),
+            chipsStackView.trailingAnchor.constraint(
+                equalTo: scrollView.trailingAnchor, constant: -Metrics.spacing4),
+        ])
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Configuration
+
+    /// Rebuilds the chips for a month. Returns whether there is anything to show, which the caller uses
+    /// to decide the strip's height - `isHidden` alone cannot collapse a view that owns one.
+    @discardableResult
+    func configure(
+        breakdown: AllocationTagBreakdown,
+        selectedTagId: String?,
+        isValuesHidden: Bool
+    ) -> Bool {
+        self.selectedTagId = selectedTagId
+
+        chipsByTagId.removeAll()
+        clearChip = nil
+        chipsStackView.arrangedSubviews.forEach {
+            chipsStackView.removeArrangedSubview($0)
+            $0.removeFromSuperview()
+        }
+
+        guard breakdown.hasTags else { return false }
+
+        for arc in breakdown.tagArcs {
+            let chip = makeChip(
+                title: arc.tag.name,
+                amount: arc.bucket.allocated,
+                inkColor: arc.tag.color.ink,
+                isValuesHidden: isValuesHidden)
+            chip.button.accessibilityLabel = accessibilityLabel(
+                for: arc, isValuesHidden: isValuesHidden)
+            chip.button.addTarget(self, action: #selector(chipTapped(_:)), for: .touchUpInside)
+            chipsByTagId[arc.id] = chip
+            chipsStackView.addArrangedSubview(chip.button)
+        }
+
+        // The untagged chip is grey and never a palette colour - it is a remainder, not a tag, and is
+        // not tappable because "everything else" is not a filter anyone asked for.
+        if let untagged = breakdown.untagged {
+            let chip = makeChip(
+                title: "budget.tags.strip.untagged".localized,
+                amount: untagged.allocated,
+                inkColor: Colors.gray400,
+                isValuesHidden: isValuesHidden)
+            chip.button.isUserInteractionEnabled = false
+            chipsStackView.addArrangedSubview(chip.button)
+        }
+
+        updateClearChip()
+        refreshSelection()
+        return true
+    }
+
+    private func makeChip(
+        title: String,
+        amount: Int,
+        inkColor: UIColor,
+        isValuesHidden: Bool
+    ) -> Chip {
+        let chip = UIButton(type: .system)
+        chip.translatesAutoresizingMaskIntoConstraints = false
+        chip.backgroundColor = Colors.gray200
+        chip.layer.borderWidth = 1
+        chip.layer.borderColor = Colors.gray300.cgColor
+        // Pill radius set here, not in `layoutSubviews`: the height is a constant, so deferring it only
+        // creates an ordering dependency on when the chip's bounds are first resolved.
+        chip.layer.cornerRadius = Self.chipHeight / 2
+        chip.heightAnchor.constraint(equalToConstant: Self.chipHeight).isActive = true
+
+        let dot = UIView()
+        dot.backgroundColor = inkColor
+        dot.layer.cornerRadius = 3.5
+        dot.translatesAutoresizingMaskIntoConstraints = false
+        dot.widthAnchor.constraint(equalToConstant: 7).isActive = true
+        dot.heightAnchor.constraint(equalToConstant: 7).isActive = true
+
+        let nameLabel = UILabel()
+        nameLabel.text = title
+        nameLabel.font = Fonts.textXS.font
+        nameLabel.textColor = Colors.gray600
+
+        let amountLabel = UILabel()
+        amountLabel.text = isValuesHidden ? "••••" : amount.compactCurrencyString
+        amountLabel.font = Fonts.titleXS.font
+        amountLabel.textColor = Colors.gray700
+
+        let stack = UIStackView(arrangedSubviews: [dot, nameLabel, amountLabel])
+        stack.axis = .horizontal
+        stack.spacing = Metrics.spacing1
+        stack.alignment = .center
+        stack.isUserInteractionEnabled = false
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        chip.addSubview(stack)
+
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(equalTo: chip.leadingAnchor, constant: Metrics.spacing3),
+            stack.trailingAnchor.constraint(equalTo: chip.trailingAnchor, constant: -Metrics.spacing3),
+            stack.centerYAnchor.constraint(equalTo: chip.centerYAnchor),
+        ])
+
+        return Chip(
+            button: chip, dot: dot, nameLabel: nameLabel, amountLabel: amountLabel,
+            inkColor: inkColor)
+    }
+
+    private func makeClearChip() -> UIButton {
+        let chip = UIButton(type: .system)
+        chip.translatesAutoresizingMaskIntoConstraints = false
+        chip.backgroundColor = Colors.gray200
+        chip.layer.borderWidth = 1
+        chip.layer.borderColor = Colors.gray300.cgColor
+        // Sized explicitly: the default symbol weight is body-sized and fills a 28pt chip edge to edge.
+        chip.setImage(
+            UIImage(
+                systemName: "xmark",
+                withConfiguration: UIImage.SymbolConfiguration(pointSize: 11, weight: .semibold)),
+            for: .normal)
+        chip.tintColor = Colors.gray500
+        chip.accessibilityLabel = "budget.tags.strip.clear".localized
+        // Pill radius set here, not in `layoutSubviews`: the height is a constant, so deferring it only
+        // creates an ordering dependency on when the chip's bounds are first resolved.
+        chip.layer.cornerRadius = Self.chipHeight / 2
+        chip.heightAnchor.constraint(equalToConstant: Self.chipHeight).isActive = true
+        chip.widthAnchor.constraint(equalToConstant: 28).isActive = true
+        chip.addTarget(self, action: #selector(clearTapped), for: .touchUpInside)
+        return chip
+    }
+
+    private func accessibilityLabel(
+        for arc: AllocationTagBreakdown.TagArc,
+        isValuesHidden: Bool
+    ) -> String {
+        guard !isValuesHidden else { return arc.tag.name }
+        let share = Int((arc.bucket.share * 100).rounded())
+        return [
+            arc.tag.name,
+            arc.bucket.allocated.compactCurrencyString,
+            String(format: "budget.tag.shareOfBudget".localized, share),
+        ].joined(separator: ", ")
+    }
+
+    /// Selected chips fill with the tag's own `ink` tone, which is the tone validated to carry
+    /// `gray100` text - the bright `arc` tone belongs on the dark card, not here.
+    func setSelectedTag(_ tagId: String?) {
+        selectedTagId = tagId
+        updateClearChip()
+        refreshSelection()
+    }
+
+    /// Keeps the clear button in step with the filter on a chip tap, not only on a full rebuild.
+    ///
+    /// Leading, not trailing: the strip scrolls, and with three tags plus an Untagged chip a trailing
+    /// clear button sits off the right edge - the one control the user needs would be the one they
+    /// cannot see. Its arrival at the front also reads as "a filter is on".
+    private func updateClearChip() {
+        if selectedTagId == nil {
+            clearChip?.removeFromSuperview()
+            clearChip = nil
+            return
+        }
+        guard clearChip == nil, !chipsByTagId.isEmpty else { return }
+        let chip = makeClearChip()
+        clearChip = chip
+        chipsStackView.insertArrangedSubview(chip, at: 0)
+    }
+
+    private func refreshSelection() {
+        for (tagId, chip) in chipsByTagId {
+            if tagId == selectedTagId {
+                chip.button.backgroundColor = chip.inkColor
+                chip.button.layer.borderWidth = 0
+                chip.dot.backgroundColor = Colors.gray100
+                chip.nameLabel.textColor = Colors.gray100
+                chip.amountLabel.textColor = Colors.gray100
+            } else {
+                chip.button.backgroundColor = Colors.gray200
+                chip.button.layer.borderWidth = 1
+                chip.button.layer.borderColor = Colors.gray300.cgColor
+                chip.dot.backgroundColor = chip.inkColor
+                chip.nameLabel.textColor = Colors.gray600
+                chip.amountLabel.textColor = Colors.gray700
+            }
+        }
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        // Left and right hairlines, drawn here rather than by the parent so this view owns its own
+        // chrome and a snapshot of it in isolation shows the real thing. Not a full `layer.border`: the
+        // top edge is the divider above and the bottom edge belongs to the table, which draws its own.
+        layer.sublayers?.removeAll { $0.name == Self.borderLayerName }
+        guard bounds.width > 0, bounds.height > 0 else { return }
+
+        let path = UIBezierPath()
+        path.move(to: CGPoint(x: 0.5, y: 0))
+        path.addLine(to: CGPoint(x: 0.5, y: bounds.height))
+        path.move(to: CGPoint(x: bounds.width - 0.5, y: 0))
+        path.addLine(to: CGPoint(x: bounds.width - 0.5, y: bounds.height))
+
+        let border = CAShapeLayer()
+        border.name = Self.borderLayerName
+        border.path = path.cgPath
+        border.fillColor = UIColor.clear.cgColor
+        border.strokeColor = Colors.gray300.cgColor
+        border.lineWidth = 1
+        border.frame = bounds
+        layer.addSublayer(border)
+    }
+
+    private static let borderLayerName = "allocationTagStrip.sideBorder"
+
+    @objc private func chipTapped(_ sender: UIButton) {
+        guard let tagId = chipsByTagId.first(where: { $0.value.button === sender })?.key else { return }
+        // Tapping the selected chip clears, matching the donut's tap-again behaviour.
+        delegate?.didSelectTag(tagId == selectedTagId ? nil : tagId)
+    }
+
+    @objc private func clearTapped() {
+        delegate?.didSelectTag(nil)
+    }
+}

--- a/Finova/Sources/Scenes/Dashboard/DashboardCarousel/MonthCarousel/BudgetCard/BudgetCard.swift
+++ b/Finova/Sources/Scenes/Dashboard/DashboardCarousel/MonthCarousel/BudgetCard/BudgetCard.swift
@@ -31,6 +31,7 @@ final class BudgetCard: UIView {
     private var isValuesHidden: Bool = false
     private var projection: AllocationBalanceProjection?
     private var tagBreakdown: AllocationTagBreakdown = .empty
+    private var selectedTagId: String?
     private var balanceBasis: BalanceBasis?
     private var currentUsedValue: Int?
     private var currentBudgetLimit: Int?
@@ -914,14 +915,35 @@ final class BudgetCard: UIView {
             unallocatedAmount: unallocatedSummary?.unallocatedAmount ?? 0,
             unallocatedSpending: unallocatedSpending,
             breakdown: tagBreakdown,
+            selectedTagId: selectedTagId,
             isValuesHidden: isValuesHidden,
             onSegmentTapped: { [weak self] category in
                 self?.delegate?.didSelectAllocationCategory(category)
             },
             onUnallocatedSpendingTapped: { [weak self] spending in
                 self?.delegate?.didTapUnallocatedSpending(spending)
+            },
+            onTagSelected: { [weak self] tagId in
+                self?.delegate?.didSelectAllocationTag(tagId)
             }
         )
+    }
+
+    /// Applies a tag selection without tearing the chart down.
+    ///
+    /// Mutates `rootView` rather than calling `embedChart()`: re-embedding replaces the
+    /// `UIHostingController` on every chip tap, which flickers the donut and throws away the SwiftUI
+    /// `@State` holding the drilled-in slice.
+    func setSelectedTag(_ tagId: String?) {
+        guard selectedTagId != tagId else { return }
+        selectedTagId = tagId
+
+        guard #available(iOS 17.0, *) else { return }
+        if let hosting = chartHostingController as? UIHostingController<BudgetDonutChartView> {
+            hosting.rootView = makeChartView()
+        } else {
+            embedChart()
+        }
     }
 
     private func embedChart() {

--- a/Finova/Sources/Scenes/Dashboard/DashboardCarousel/MonthCarousel/BudgetCard/BudgetCard.swift
+++ b/Finova/Sources/Scenes/Dashboard/DashboardCarousel/MonthCarousel/BudgetCard/BudgetCard.swift
@@ -820,13 +820,19 @@ final class BudgetCard: UIView {
 
         projectionTextLabel.text = caption
 
-        // Of what was spent, how much stayed inside its allocation. Proportions, not amounts, so
-        // the bar survives value-hiding; before anything is spent both shares are zero and the
-        // bare grey track shows through.
+        // Three quantities, compared: what the balance ends up with, what is being saved, what broke out
+        // of the plan. Proportions, not amounts, so the bar survives value-hiding; with nothing to
+        // divide every share is zero and the bare grey track shows through.
+        //
+        // The projected slice is magenta, not green. It is what remains *after* savings come out of it,
+        // so it is not the saved figure, and green here would claim the whole balance is being kept -
+        // which is exactly what the two earlier versions of this bar wrongly said. Magenta matches the
+        // spend gauge along the card's bottom edge, which plots the same idea.
         let shares = projection.barShares
         projectionBar.setSegments([
-            SegmentedBarView.Segment(share: shares.withinPlan, color: Colors.brightGreen),
-            SegmentedBarView.Segment(share: shares.beyondPlan, color: Colors.brightRed),
+            SegmentedBarView.Segment(share: shares.projected, color: Colors.mainMagenta),
+            SegmentedBarView.Segment(share: shares.saved, color: Colors.brightGreen),
+            SegmentedBarView.Segment(share: shares.overspent, color: Colors.brightRed),
         ])
 
         guard !isValuesHidden else {
@@ -850,11 +856,12 @@ final class BudgetCard: UIView {
 
         var spokenParts = [caption, valueText]
 
-        // The bar carries no visible legend at this width, so spell its two sides out here.
-        if projection.usedWithinAllocations > 0 {
+        // The bar carries no visible legend at this width, so name its green and red sides. The magenta
+        // side is the headline immediately above, so repeating it would only pad.
+        if projection.totalSaved > 0 {
             spokenParts.append(
-                "budget.plan.within.label".localized + " "
-                    + projection.usedWithinAllocations.compactCurrencyString)
+                "budget.projection.saved.format".localized(
+                    projection.totalSaved.compactCurrencyString))
         }
         if projection.overspent > 0 {
             spokenParts.append(

--- a/Finova/Sources/Scenes/Dashboard/DashboardCarousel/MonthCarousel/BudgetCard/BudgetCard.swift
+++ b/Finova/Sources/Scenes/Dashboard/DashboardCarousel/MonthCarousel/BudgetCard/BudgetCard.swift
@@ -30,6 +30,7 @@ final class BudgetCard: UIView {
     private var currentMonthAnchor: Int = 0
     private var isValuesHidden: Bool = false
     private var projection: AllocationBalanceProjection?
+    private var tagBreakdown: AllocationTagBreakdown = .empty
     private var balanceBasis: BalanceBasis?
     private var currentUsedValue: Int?
     private var currentBudgetLimit: Int?
@@ -593,12 +594,27 @@ final class BudgetCard: UIView {
         unallocatedSummary: UnallocatedBudgetSummary,
         unallocatedSpending: [UnallocatedCategorySpending],
         monthAnchor: Int,
-        monthData: MonthBudgetCardType? = nil
+        monthData: MonthBudgetCardType? = nil,
+        tagBreakdown: AllocationTagBreakdown = .empty
     ) {
         self.allocations = allocations
         self.unallocatedSummary = unallocatedSummary
         self.unallocatedSpending = unallocatedSpending
         self.currentMonthAnchor = monthAnchor
+
+        // Always hand the donut a populated breakdown, even when there are no tags: it drives slice
+        // order from it, so leaving it empty would mean a second rendering path to keep in step. A
+        // caller that passes none - the layout tests - gets a tagless one built from the same values.
+        self.tagBreakdown =
+            tagBreakdown.segments.isEmpty
+            ? AllocationTagBreakdown(
+                allocations: allocations,
+                unallocatedSpending: unallocatedSpending,
+                unallocatedHeadroom: unallocatedSummary.unallocatedAmount,
+                totalBudget: unallocatedSummary.totalBudget,
+                tags: [],
+                categoryTagIds: [:])
+            : tagBreakdown
 
         // Retained so `updateValuesDisplay()` can refresh the spend gauge and the footer without
         // `monthData` in scope.
@@ -890,18 +906,14 @@ final class BudgetCard: UIView {
         noBudgetStateView.isHidden = false
     }
 
-    private func embedChart() {
-        // Remove existing chart if any
-        chartHostingController?.view.removeFromSuperview()
-        chartHostingController = nil
-
-        guard #available(iOS 17.0, *) else { return }
-
-        let chartView = BudgetDonutChartView(
+    @available(iOS 17.0, *)
+    private func makeChartView() -> BudgetDonutChartView {
+        BudgetDonutChartView(
             allocations: allocations,
             totalBudget: unallocatedSummary?.totalBudget ?? 0,
             unallocatedAmount: unallocatedSummary?.unallocatedAmount ?? 0,
             unallocatedSpending: unallocatedSpending,
+            breakdown: tagBreakdown,
             isValuesHidden: isValuesHidden,
             onSegmentTapped: { [weak self] category in
                 self?.delegate?.didSelectAllocationCategory(category)
@@ -910,8 +922,16 @@ final class BudgetCard: UIView {
                 self?.delegate?.didTapUnallocatedSpending(spending)
             }
         )
+    }
 
-        let hostingController = UIHostingController(rootView: chartView)
+    private func embedChart() {
+        // Remove existing chart if any
+        chartHostingController?.view.removeFromSuperview()
+        chartHostingController = nil
+
+        guard #available(iOS 17.0, *) else { return }
+
+        let hostingController = UIHostingController(rootView: makeChartView())
         hostingController.view.backgroundColor = .clear
         hostingController.view.translatesAutoresizingMaskIntoConstraints = false
 

--- a/Finova/Sources/Scenes/Dashboard/DashboardCarousel/MonthCarousel/MonthCardFlipDelegate.swift
+++ b/Finova/Sources/Scenes/Dashboard/DashboardCarousel/MonthCarousel/MonthCardFlipDelegate.swift
@@ -10,6 +10,8 @@ import UIKit
 protocol MonthCardFlipDelegate: AnyObject {
     func didRequestFlip(isShowingBudgetView: Bool)
     func didSelectAllocationCategory(_ category: TransactionCategory)
+    /// A tag arc on the donut was tapped. `nil` clears the selection.
+    func didSelectAllocationTag(_ tagId: String?)
     func didTapAllocation(_ allocation: BudgetAllocation)
     func didTapUnallocatedSpending(_ spending: UnallocatedCategorySpending)
     func didTapBudgetsConfig(forMonth monthAnchor: Int)

--- a/Finova/Sources/Scenes/Dashboard/DashboardCarousel/MonthCarousel/MonthCarouselCell.swift
+++ b/Finova/Sources/Scenes/Dashboard/DashboardCarousel/MonthCarousel/MonthCarouselCell.swift
@@ -94,6 +94,24 @@ class MonthCarouselCell: UICollectionViewCell {
     private var currentUnallocatedSpending: [UnallocatedCategorySpending] = []
     private(set) var currentMonthAnchor: Int = 0
     private let allocationService = BudgetAllocationService()
+    private let tagService = AllocationTagService.shared
+
+    private var tagBreakdown: AllocationTagBreakdown = .empty
+    /// The tag the list and donut are filtered to, or nil. Cleared on reuse and clamped on every
+    /// rebuild - a tag with no members in the newly shown month would otherwise filter the list to
+    /// nothing with no chip left to clear it.
+    private var selectedTagId: String?
+
+    /// The rows the table actually shows. Precomputed rather than filtered inside the data source,
+    /// which runs per row per layout pass.
+    private var visibleAllocations: [BudgetAllocation] = []
+    private var visibleUnallocatedSpending: [UnallocatedCategorySpending] = []
+
+    /// Single source of truth for "how many rows are there", so the count badge, the table height and
+    /// `numberOfRowsInSection` can never disagree.
+    private var visibleRowCount: Int {
+        visibleAllocations.count + visibleUnallocatedSpending.count
+    }
 
     /// Resolves the displayed month's ledger row on demand, for the budget card's projected
     /// balance. Deliberately pull-based rather than a stored snapshot: while the budget face is
@@ -305,6 +323,22 @@ class MonthCarouselCell: UICollectionViewCell {
         return stackView
     }()
 
+    /// Per-tag subtotals and the list filter. A sibling between the header and the table, not part of
+    /// either: the header's 44pt height constraint is activated inline above with no stored reference,
+    /// so it can never be made taller.
+    private lazy var allocationTagStripView: AllocationTagStripView = {
+        let view = AllocationTagStripView()
+        view.delegate = self
+        view.isHidden = true
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    /// Stored, deliberately unlike the header's, because it has to collapse to zero when a month has no
+    /// tag arcs. `isHidden` alone leaves a view that owns a height constraint occupying its height, so
+    /// the table would simply sit 44pt lower behind an empty band.
+    private var tagStripHeightConstraint: NSLayoutConstraint?
+
     private let allocationsHeaderTitleLabel: UILabel = {
         let label = UILabel()
         label.fontStyle = Fonts.title2XS
@@ -411,41 +445,148 @@ class MonthCarouselCell: UICollectionViewCell {
             name: .allocationDataChanged,
             object: nil
         )
+        // Tag edits change the strip and the ring without touching a single allocation, so they need
+        // their own signal - `.allocationDataChanged` is never posted for them.
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleAllocationTagsChanged),
+            name: .allocationTagsChanged,
+            object: nil
+        )
     }
 
-    @objc private func handleAllocationDataChanged() {
-        // Only refresh if currently showing budget view
+    @objc private func handleAllocationTagsChanged() {
+        guard Thread.isMainThread else {
+            DispatchQueue.main.async { [weak self] in self?.handleAllocationTagsChanged() }
+            return
+        }
         guard isShowingBudgetView else { return }
+        rebuildAllocationsUI()
+    }
 
-        // Fetch fresh data and update the budget card
-        let allocations = allocationService.getAllocationsWithUsage(forMonth: currentMonthAnchor)
-        let unallocatedSpending = allocationService.getUnallocatedCategoriesWithSpending(forMonth: currentMonthAnchor)
-        let summary = allocationService.getUnallocatedSummary(forMonth: currentMonthAnchor)
+    // MARK: - Allocations rebuild funnel
 
-        // Sort allocations by allocated amount (highest first)
-        currentAllocations = allocations.sorted { $0.allocatedAmount > $1.allocatedAmount }
-        currentUnallocatedSpending = unallocatedSpending
-        allocationsTableView.reloadData()
+    /// The one place the allocations side of this cell is rebuilt.
+    ///
+    /// Six paths used to each fetch, sort, reload, set the badge and reconfigure the card in their own
+    /// near-identical block. Anything added to that work had to be added six times, and the four blocks
+    /// that also flipped `isHidden` were one edit away from disagreeing about which views exist.
+    ///
+    /// Passing nil for any argument fetches it, so callers that already hold fresh data do not pay for
+    /// a second read.
+    private func rebuildAllocationsUI(
+        allocations: [BudgetAllocation]? = nil,
+        unallocatedSpending: [UnallocatedCategorySpending]? = nil,
+        summary: UnallocatedBudgetSummary? = nil
+    ) {
+        // No ledger scope on this branch: `LedgerScope` arrives with group sync in 1.6.0, and these
+        // service methods take no scope here. Everything is personal-scoped, which is what the rest of
+        // this file already assumes.
+        let resolvedAllocations =
+            allocations ?? allocationService.getAllocationsWithUsage(forMonth: currentMonthAnchor)
+        let resolvedSpending =
+            unallocatedSpending
+            ?? allocationService.getUnallocatedCategoriesWithSpending(forMonth: currentMonthAnchor)
+        let resolvedSummary =
+            summary ?? allocationService.getUnallocatedSummary(forMonth: currentMonthAnchor)
 
-        // Total count includes both allocated and unallocated with spending
-        let totalCount = allocations.count + unallocatedSpending.count
-        allocationsNumberLabel.text = "\(totalCount)"
-        updateAllocationsTableHeight(count: totalCount)
+        // Sorted for the list, as before. The card is handed the same sorted array now rather than the
+        // unsorted one, so the donut and the rows beneath it agree about order.
+        currentAllocations = resolvedAllocations.sorted { $0.allocatedAmount > $1.allocatedAmount }
+        currentUnallocatedSpending = resolvedSpending
+
+        let book = tagService.book
+        tagBreakdown = AllocationTagBreakdown(
+            allocations: currentAllocations,
+            unallocatedSpending: currentUnallocatedSpending,
+            unallocatedHeadroom: resolvedSummary.unallocatedAmount,
+            totalBudget: resolvedSummary.totalBudget,
+            tags: book.orderedTags,
+            categoryTagIds: book.categoryTagIds)
+
+        // A tag with no arc this month cannot be shown as selected, so it cannot be cleared either.
+        if let selectedTagId, tagBreakdown.arc(id: selectedTagId) == nil {
+            self.selectedTagId = nil
+        }
+
+        let hasStrip = allocationTagStripView.configure(
+            breakdown: tagBreakdown,
+            selectedTagId: selectedTagId,
+            isValuesHidden: UserDefaultsManager.getHideValues())
+        tagStripHeightConstraint?.constant = hasStrip ? AllocationTagStripView.preferredHeight : 0
 
         budgetCard.configure(
             month: monthCard.currentMonth,
             year: monthCard.currentYear,
-            allocations: allocations,
-            unallocatedSummary: summary,
+            allocations: currentAllocations,
+            unallocatedSummary: resolvedSummary,
             unallocatedSpending: currentUnallocatedSpending,
             monthAnchor: currentMonthAnchor,
-            monthData: currentMonthData
+            monthData: currentMonthData,
+            tagBreakdown: tagBreakdown
         )
+        budgetCard.setSelectedTag(selectedTagId)
 
-        // Show/hide empty state - show table if there are allocations OR unallocated spending
-        let hasContent = !allocations.isEmpty || !unallocatedSpending.isEmpty
-        allocationsTableView.isHidden = !hasContent
-        allocationsEmptyStateView.isHidden = hasContent
+        applyTagFilter()
+    }
+
+    /// Recomputes the visible rows from `selectedTagId` and brings the table, badge and empty state in
+    /// line. Split from `rebuildAllocationsUI` so a chip tap does not refetch anything.
+    private func applyTagFilter() {
+        if let selectedTagId {
+            visibleAllocations = currentAllocations.filter {
+                tagBreakdown.segment("alloc-\($0.category.key)", belongsTo: selectedTagId)
+            }
+            visibleUnallocatedSpending = currentUnallocatedSpending.filter {
+                tagBreakdown.segment("offplan-\($0.category.key)", belongsTo: selectedTagId)
+            }
+        } else {
+            visibleAllocations = currentAllocations
+            visibleUnallocatedSpending = currentUnallocatedSpending
+        }
+
+        allocationsTableView.reloadData()
+        // The honest reading of a number sitting beside a filtered list.
+        allocationsNumberLabel.text = "\(visibleRowCount)"
+        updateAllocationsTableHeight(count: visibleRowCount)
+        allocationTagStripView.setSelectedTag(selectedTagId)
+
+        // A filter that matches nothing shows the empty state with its own wording, rather than a
+        // zero-row table that looks like a loading bug.
+        allocationsEmptyStateDescriptionLabel.text =
+            selectedTagId == nil
+            ? "budget.allocations.emptyState.description".localized
+            : "budget.allocations.emptyState.filtered".localized
+
+        if isShowingBudgetView {
+            let hasContent = visibleRowCount > 0
+            allocationsTableView.isHidden = !hasContent
+            allocationsEmptyStateView.isHidden = hasContent
+        }
+    }
+
+    /// Declares the set of views that belong to the allocations face exactly once. Four paths write
+    /// these together, and missing one leaves a stray band floating over the transactions list.
+    private func setAllocationsViewsHidden(_ hidden: Bool, hasContent: Bool) {
+        allocationsTableHeaderView.isHidden = hidden
+        allocationTagStripView.isHidden = hidden || (tagStripHeightConstraint?.constant ?? 0) == 0
+        allocationsTableView.isHidden = hidden || !hasContent
+        allocationsEmptyStateView.isHidden = hidden || hasContent
+    }
+
+    @objc private func handleAllocationDataChanged() {
+        // This handler touches UIKit directly, and `.allocationDataChanged` is posted from
+        // background write/sync paths too — NotificationCenter delivers on the posting thread,
+        // so bounce to main before doing anything.
+        guard Thread.isMainThread else {
+            DispatchQueue.main.async { [weak self] in self?.handleAllocationDataChanged() }
+            return
+        }
+
+        // Only refresh if currently showing budget view
+        guard isShowingBudgetView else { return }
+
+        rebuildAllocationsUI()
     }
 
     private func setupViews() {
@@ -494,6 +635,7 @@ class MonthCarouselCell: UICollectionViewCell {
         allocationsTableHeaderView.addArrangedSubview(allocationsHeaderTitleLabel)
         allocationsTableHeaderView.addArrangedSubview(allocationsNumberContainerView)
         allocationsNumberContainerView.addArrangedSubview(allocationsNumberLabel)
+        contentView.addSubview(allocationTagStripView)
         contentView.addSubview(allocationsTableView)
         contentView.addSubview(allocationsEmptyStateView)
         allocationsEmptyStateView.addSubview(allocationsEmptyStateIconImageView)
@@ -575,11 +717,18 @@ class MonthCarouselCell: UICollectionViewCell {
             allocationsTableHeaderView.leadingAnchor.constraint(equalTo: monthCard.leadingAnchor),
             allocationsTableHeaderView.trailingAnchor.constraint(equalTo: monthCard.trailingAnchor),
 
-            allocationsTableView.topAnchor.constraint(equalTo: allocationsTableHeaderView.bottomAnchor),
+            // The strip sits between the header and both content views, so those two now hang off it
+            // rather than off the header. At zero height it is layout-neutral.
+            allocationTagStripView.topAnchor.constraint(
+                equalTo: allocationsTableHeaderView.bottomAnchor),
+            allocationTagStripView.leadingAnchor.constraint(equalTo: monthCard.leadingAnchor),
+            allocationTagStripView.trailingAnchor.constraint(equalTo: monthCard.trailingAnchor),
+
+            allocationsTableView.topAnchor.constraint(equalTo: allocationTagStripView.bottomAnchor),
             allocationsTableView.leadingAnchor.constraint(equalTo: monthCard.leadingAnchor),
             allocationsTableView.trailingAnchor.constraint(equalTo: monthCard.trailingAnchor),
 
-            allocationsEmptyStateView.topAnchor.constraint(equalTo: allocationsTableHeaderView.bottomAnchor),
+            allocationsEmptyStateView.topAnchor.constraint(equalTo: allocationTagStripView.bottomAnchor),
             allocationsEmptyStateView.leadingAnchor.constraint(equalTo: monthCard.leadingAnchor),
             allocationsEmptyStateView.trailingAnchor.constraint(equalTo: monthCard.trailingAnchor),
             allocationsEmptyStateView.heightAnchor.constraint(equalToConstant: Metrics.tableEmptyViewHeight),
@@ -596,6 +745,9 @@ class MonthCarouselCell: UICollectionViewCell {
                 equalTo: allocationsEmptyStateView.trailingAnchor, constant: -Metrics.spacing4),
             allocationsEmptyStateDescriptionLabel.centerYAnchor.constraint(equalTo: allocationsEmptyStateView.centerYAnchor),
         ])
+
+        tagStripHeightConstraint = allocationTagStripView.heightAnchor.constraint(equalToConstant: 0)
+        tagStripHeightConstraint?.isActive = true
     }
     
     func configure(with model: MonthBudgetCardType, transactions: [Transaction]) {
@@ -992,31 +1144,8 @@ class MonthCarouselCell: UICollectionViewCell {
         monthCard.setShowingBudgetView(true)
         onBudgetViewStateChanged?(currentMonthAnchor, true)
 
-        // Store allocations sorted by allocated amount (highest first)
-        currentAllocations = allocations.sorted { $0.allocatedAmount > $1.allocatedAmount }
-
-        // Fetch unallocated categories with spending
-        currentUnallocatedSpending = allocationService.getUnallocatedCategoriesWithSpending(forMonth: currentMonthAnchor)
-
-        allocationsTableView.reloadData()
-
-        // Total count includes both allocated and unallocated with spending
-        let totalCount = allocations.count + currentUnallocatedSpending.count
-        allocationsNumberLabel.text = "\(totalCount)"
-        updateAllocationsTableHeight(count: totalCount)
-
-        budgetCard.configure(
-            month: monthCard.currentMonth,
-            year: monthCard.currentYear,
-            allocations: allocations,
-            unallocatedSummary: summary,
-            unallocatedSpending: currentUnallocatedSpending,
-            monthAnchor: currentMonthAnchor,
-            monthData: currentMonthData
-        )
-
-        // Show table if there are allocations OR unallocated spending
-        let hasContent = !allocations.isEmpty || !currentUnallocatedSpending.isEmpty
+        rebuildAllocationsUI(allocations: allocations, summary: summary)
+        let hasContent = visibleRowCount > 0
 
         // Disable transaction table interaction BEFORE animation to prevent stale taps
         transactionTableView.isUserInteractionEnabled = false
@@ -1035,9 +1164,7 @@ class MonthCarouselCell: UICollectionViewCell {
             self.transactionTableView.isHidden = true
             self.emptyStateView.isHidden = true
             // Show allocations table components
-            self.allocationsTableHeaderView.isHidden = false
-            self.allocationsTableView.isHidden = !hasContent
-            self.allocationsEmptyStateView.isHidden = hasContent
+            self.setAllocationsViewsHidden(false, hasContent: hasContent)
         } completion: { _ in
             // Enable allocation table interaction after animation completes
             self.allocationsTableView.isUserInteractionEnabled = true
@@ -1070,9 +1197,7 @@ class MonthCarouselCell: UICollectionViewCell {
             self.transactionTableView.isHidden = !hasTransactions
             self.emptyStateView.isHidden = hasTransactions
             // Hide allocations table components
-            self.allocationsTableHeaderView.isHidden = true
-            self.allocationsTableView.isHidden = true
-            self.allocationsEmptyStateView.isHidden = true
+            self.setAllocationsViewsHidden(true, hasContent: false)
         } completion: { _ in
             // Enable transaction table interaction after animation completes
             self.transactionTableView.isUserInteractionEnabled = true
@@ -1086,36 +1211,12 @@ class MonthCarouselCell: UICollectionViewCell {
         isShowingBudgetView = true
         monthCard.setShowingBudgetView(true)
 
-        // Sort allocations by allocated amount (highest first)
-        currentAllocations = allocations.sorted { $0.allocatedAmount > $1.allocatedAmount }
-
-        // Fetch unallocated categories with spending
-        currentUnallocatedSpending = allocationService.getUnallocatedCategoriesWithSpending(forMonth: currentMonthAnchor)
-
         // Reset scroll position and state before reloading
         allocationsTableView.setContentOffset(.zero, animated: false)
         allocationsTableView.contentInset = .zero
         allocationsTableView.scrollIndicatorInsets = .zero
 
-        allocationsTableView.reloadData()
-
-        // Total count includes both allocated and unallocated with spending
-        let totalCount = allocations.count + currentUnallocatedSpending.count
-        allocationsNumberLabel.text = "\(totalCount)"
-        updateAllocationsTableHeight(count: totalCount)
-
-        budgetCard.configure(
-            month: monthCard.currentMonth,
-            year: monthCard.currentYear,
-            allocations: allocations,
-            unallocatedSummary: summary,
-            unallocatedSpending: currentUnallocatedSpending,
-            monthAnchor: currentMonthAnchor,
-            monthData: currentMonthData
-        )
-
-        // Show table if there are allocations OR unallocated spending
-        let hasContent = !allocations.isEmpty || !currentUnallocatedSpending.isEmpty
+        rebuildAllocationsUI(allocations: allocations, summary: summary)
 
         // Set state directly without animation
         monthCard.isHidden = true
@@ -1124,9 +1225,7 @@ class MonthCarouselCell: UICollectionViewCell {
         tableHeaderView.isHidden = true
         transactionTableView.isHidden = true
         emptyStateView.isHidden = true
-        allocationsTableHeaderView.isHidden = false
-        allocationsTableView.isHidden = !hasContent
-        allocationsEmptyStateView.isHidden = hasContent
+        setAllocationsViewsHidden(false, hasContent: visibleRowCount > 0)
 
         // Ensure correct user interaction state for budget view
         transactionTableView.isUserInteractionEnabled = false
@@ -1137,38 +1236,12 @@ class MonthCarouselCell: UICollectionViewCell {
     func refreshBudgetView(allocations: [BudgetAllocation], summary: UnallocatedBudgetSummary) {
         guard isShowingBudgetView else { return }
 
-        // Sort allocations by allocated amount (highest first)
-        currentAllocations = allocations.sorted { $0.allocatedAmount > $1.allocatedAmount }
-
-        // Fetch unallocated categories with spending
-        currentUnallocatedSpending = allocationService.getUnallocatedCategoriesWithSpending(forMonth: currentMonthAnchor)
-
         // Reset scroll position and state before reloading
         allocationsTableView.setContentOffset(.zero, animated: false)
         allocationsTableView.contentInset = .zero
         allocationsTableView.scrollIndicatorInsets = .zero
 
-        allocationsTableView.reloadData()
-
-        // Total count includes both allocated and unallocated with spending
-        let totalCount = allocations.count + currentUnallocatedSpending.count
-        allocationsNumberLabel.text = "\(totalCount)"
-        updateAllocationsTableHeight(count: totalCount)
-
-        budgetCard.configure(
-            month: monthCard.currentMonth,
-            year: monthCard.currentYear,
-            allocations: allocations,
-            unallocatedSummary: summary,
-            unallocatedSpending: currentUnallocatedSpending,
-            monthAnchor: currentMonthAnchor,
-            monthData: currentMonthData
-        )
-
-        // Update visibility based on content
-        let hasContent = !allocations.isEmpty || !currentUnallocatedSpending.isEmpty
-        allocationsTableView.isHidden = !hasContent
-        allocationsEmptyStateView.isHidden = hasContent
+        rebuildAllocationsUI(allocations: allocations, summary: summary)
 
         // Ensure correct user interaction state
         transactionTableView.isUserInteractionEnabled = false
@@ -1208,7 +1281,10 @@ class MonthCarouselCell: UICollectionViewCell {
         // Use budget card height (it sizes itself)
         let budgetCardHeight = budgetCard.bounds.height > 0 ? budgetCard.bounds.height : 220
         let spacingAfterCard = Metrics.spacing4
-        let tableHeaderHeight = Metrics.spacing11
+        // The chip strip sits between the header and the table, so its height is part of what the
+        // table does NOT get. Omitting it makes the table 44pt too tall - and the clamp below absorbs
+        // that on tall devices, so it passes casual testing and then clips rows on a small one.
+        let tableHeaderHeight = Metrics.spacing11 + (tagStripHeightConstraint?.constant ?? 0)
         let bottomPadding = Metrics.spacing4
 
         let fixedComponentsHeight = topPadding + budgetCardHeight + spacingAfterCard + tableHeaderHeight + bottomPadding
@@ -1232,9 +1308,11 @@ class MonthCarouselCell: UICollectionViewCell {
             updateTableHeight(txsCount: currentCount)
         }
 
-        // Update allocations table height when in budget view
-        if isShowingBudgetView && !currentAllocations.isEmpty {
-            updateAllocationsTableHeight(count: currentAllocations.count)
+        // Update allocations table height when in budget view. Uses `visibleRowCount`, which is what
+        // `numberOfRowsInSection` returns - this used to pass `currentAllocations.count`, dropping the
+        // unallocated-spending rows, so a month with only off-plan spend never recomputed at all.
+        if isShowingBudgetView && visibleRowCount > 0 {
+            updateAllocationsTableHeight(count: visibleRowCount)
         }
         
         transactionsNumberContainerView.layoutIfNeeded()
@@ -1259,6 +1337,8 @@ class MonthCarouselCell: UICollectionViewCell {
         allocationsTableHeaderView.layer.sublayers?.removeAll(where: { $0 is CAShapeLayer })
         allocationsTableHeaderView.layoutIfNeeded()
         addBordersExceptBottom(to: allocationsTableHeaderView, color: Colors.gray300)
+
+        // The strip draws its own side hairlines; nothing to do for it here.
     }
     
     override func prepareForReuse() {
@@ -1278,6 +1358,7 @@ class MonthCarouselCell: UICollectionViewCell {
         transactionTableView.alpha = 1
         emptyStateView.alpha = 1
         allocationsTableHeaderView.alpha = 1
+        allocationTagStripView.alpha = 1
         allocationsTableView.alpha = 1
         allocationsEmptyStateView.alpha = 1
 
@@ -1298,6 +1379,15 @@ class MonthCarouselCell: UICollectionViewCell {
         allocationsTableHeightConstraint = nil
         currentAllocations = []
         currentUnallocatedSpending = []
+
+        // Cells are reused, so a filter left set here would apply to a different month - and if that
+        // month has no such tag, to a list with no chip left to clear it. Same class of bug that
+        // `currentFilters.clear()` below guards for the transaction face.
+        selectedTagId = nil
+        tagBreakdown = .empty
+        visibleAllocations = []
+        visibleUnallocatedSpending = []
+        tagStripHeightConstraint?.constant = 0
 
         // Reset scroll state to default
         transactionTableView.isScrollEnabled = false
@@ -1322,9 +1412,7 @@ class MonthCarouselCell: UICollectionViewCell {
         // Hide both table and empty state during cell setup to prevent flashing
         transactionTableView.isHidden = true
         emptyStateView.isHidden = true
-        allocationsTableHeaderView.isHidden = true
-        allocationsTableView.isHidden = true
-        allocationsEmptyStateView.isHidden = true
+        setAllocationsViewsHidden(true, hasContent: false)
 
         clearSearch()
     }
@@ -1414,6 +1502,29 @@ extension MonthCarouselCell: MonthCardFlipDelegate {
     func didToggleBalanceVisibility(_ isHidden: Bool) {
         onBalanceVisibilityToggled?(isHidden)
     }
+
+    func didSelectAllocationTag(_ tagId: String?) {
+        applySelectedTag(tagId)
+    }
+}
+
+// MARK: - AllocationTagStripViewDelegate
+
+extension MonthCarouselCell: AllocationTagStripViewDelegate {
+    func didSelectTag(_ tagId: String?) {
+        applySelectedTag(tagId)
+    }
+}
+
+extension MonthCarouselCell {
+    /// One entry point for both the donut arc and the chip strip, so the two can never disagree about
+    /// what is selected. Deliberately does not refetch: only the filter changed.
+    private func applySelectedTag(_ tagId: String?) {
+        guard selectedTagId != tagId else { return }
+        selectedTagId = tagId
+        budgetCard.setSelectedTag(tagId)
+        applyTagFilter()
+    }
 }
 
 // MARK: - UITableViewDataSource & UITableViewDelegate for Allocations
@@ -1422,8 +1533,9 @@ extension MonthCarouselCell: UITableViewDataSource, UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         if tableView === allocationsTableView {
-            // Total count: allocated items first, then unallocated items
-            return currentAllocations.count + currentUnallocatedSpending.count
+            // Total count: allocated items first, then unallocated items. `visible*` rather than
+            // `current*` so a tag filter narrows the list.
+            return visibleRowCount
         }
         return 0
     }
@@ -1438,17 +1550,17 @@ extension MonthCarouselCell: UITableViewDataSource, UITableViewDelegate {
             }
 
             // Check if this is an allocated or unallocated row
-            if indexPath.row < currentAllocations.count {
+            if indexPath.row < visibleAllocations.count {
                 // Allocated category
-                let allocation = currentAllocations[indexPath.row]
+                let allocation = visibleAllocations[indexPath.row]
                 cell.configure(with: allocation)
                 cell.setTapAction { [weak self] in
                     self?.didTapAllocation(allocation)
                 }
             } else {
                 // Unallocated category with spending
-                let unallocatedIndex = indexPath.row - currentAllocations.count
-                let unallocatedSpending = currentUnallocatedSpending[unallocatedIndex]
+                let unallocatedIndex = indexPath.row - visibleAllocations.count
+                let unallocatedSpending = visibleUnallocatedSpending[unallocatedIndex]
                 cell.configure(with: unallocatedSpending)
                 cell.setTapAction { [weak self] in
                     guard let self = self else { return }

--- a/Finova/Sources/Scenes/Dashboard/DashboardCarousel/MonthCarousel/MonthCarouselCell.swift
+++ b/Finova/Sources/Scenes/Dashboard/DashboardCarousel/MonthCarousel/MonthCarouselCell.swift
@@ -77,6 +77,8 @@ class MonthCarouselCell: UICollectionViewCell {
     var onDefineBudgetTapped: ((Int) -> Void)?
     var onBudgetViewStateChanged: ((Int, Bool) -> Void)?  // (monthAnchor, isShowingBudgetView)
     var onBalanceVisibilityToggled: ((Bool) -> Void)?
+    var onManageTagsTapped: (() -> Void)?
+    var onCreateTagTapped: (() -> Void)?
 
     // MARK: - Properties
 
@@ -374,6 +376,30 @@ class MonthCarouselCell: UICollectionViewCell {
         return label
     }()
 
+    /// Groups the title and its count pill so the header's `.equalSpacing` puts the pair at the leading
+    /// edge and the Tags button at the trailing one. Without the group, three arranged subviews spread
+    /// evenly and the count pill drifts to the middle of the row.
+    private lazy var allocationsHeaderLeadingStack: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .horizontal
+        stack.alignment = .center
+        stack.spacing = Metrics.spacing2
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        return stack
+    }()
+
+    /// Reaches tag management from the dashboard, so it does not require going through the gear and the
+    /// Budgets screen. Also the only entry point when a month has no tags at all, since the strip - and
+    /// with it the `+` chip - collapses to nothing in that case.
+    private let allocationsTagsButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("budgets.tags.manage".localized, for: .normal)
+        button.titleLabel?.font = Fonts.titleXS.font
+        button.setTitleColor(Colors.mainMagenta, for: .normal)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+
     lazy var allocationsTableView: UITableView = {
         let tableView = UITableView()
         tableView.backgroundColor = Colors.gray100
@@ -453,6 +479,10 @@ class MonthCarouselCell: UICollectionViewCell {
             name: .allocationTagsChanged,
             object: nil
         )
+    }
+
+    @objc private func manageTagsTapped() {
+        onManageTagsTapped?()
     }
 
     @objc private func handleAllocationTagsChanged() {
@@ -632,9 +662,13 @@ class MonthCarouselCell: UICollectionViewCell {
 
         // Allocations table components
         contentView.addSubview(allocationsTableHeaderView)
-        allocationsTableHeaderView.addArrangedSubview(allocationsHeaderTitleLabel)
-        allocationsTableHeaderView.addArrangedSubview(allocationsNumberContainerView)
+        allocationsHeaderLeadingStack.addArrangedSubview(allocationsHeaderTitleLabel)
+        allocationsHeaderLeadingStack.addArrangedSubview(allocationsNumberContainerView)
+        allocationsTableHeaderView.addArrangedSubview(allocationsHeaderLeadingStack)
+        allocationsTableHeaderView.addArrangedSubview(allocationsTagsButton)
         allocationsNumberContainerView.addArrangedSubview(allocationsNumberLabel)
+        allocationsTagsButton.addTarget(
+            self, action: #selector(manageTagsTapped), for: .touchUpInside)
         contentView.addSubview(allocationTagStripView)
         contentView.addSubview(allocationsTableView)
         contentView.addSubview(allocationsEmptyStateView)
@@ -1513,6 +1547,10 @@ extension MonthCarouselCell: MonthCardFlipDelegate {
 extension MonthCarouselCell: AllocationTagStripViewDelegate {
     func didSelectTag(_ tagId: String?) {
         applySelectedTag(tagId)
+    }
+
+    func didTapCreateTag() {
+        onCreateTagTapped?()
     }
 }
 

--- a/Finova/Sources/Scenes/Dashboard/DashboardFlowDelegate.swift
+++ b/Finova/Sources/Scenes/Dashboard/DashboardFlowDelegate.swift
@@ -19,4 +19,8 @@ protocol DashboardFlowDelegate: AnyObject {
     func navigateToUnallocatedDetails(unallocatedSpending: UnallocatedCategorySpending)
     func navigateToStatementDetails(card: CreditCard, statement: CreditCardStatement)
     func openAdjustBalanceModal(currentBalance: Int)
+    func navigateToAllocationTags()
+    /// Creates a tag from the dashboard and goes straight to linking its categories - the same flow the
+    /// Tags list uses, so the two entry points cannot drift apart.
+    func presentCreateAllocationTag()
 }

--- a/Finova/Sources/Scenes/Dashboard/DashboardViewController.swift
+++ b/Finova/Sources/Scenes/Dashboard/DashboardViewController.swift
@@ -1360,6 +1360,12 @@ extension DashboardViewController: UICollectionViewDataSource {
             cell.onBalanceVisibilityToggled = { [weak self] isHidden in
                 self?.updateAllMonthCardsBalanceVisibility(isHidden)
             }
+            cell.onManageTagsTapped = { [weak self] in
+                self?.flowDelegate?.navigateToAllocationTags()
+            }
+            cell.onCreateTagTapped = { [weak self] in
+                self?.flowDelegate?.presentCreateAllocationTag()
+            }
 
             cell.transactionTableView.dataSource = self
             cell.transactionTableView.delegate = self

--- a/Finova/Sources/SwiftUI/Charts/BudgetDonutChartView.swift
+++ b/Finova/Sources/SwiftUI/Charts/BudgetDonutChartView.swift
@@ -349,7 +349,12 @@ struct BudgetDonutChartView: View {
                             Image(uiImage: icon)
                                 .resizable()
                                 .renderingMode(.template)
-                                .foregroundColor(colorForAllocation(allocation))
+                                // Full-strength magenta, NOT `colorForAllocation`. That ramp scales
+                                // brightness from 0.35 to 1.0 by slice size, which is meaningful on the
+                                // ring - bigger reads brighter - but in the centre it only makes a small
+                                // category's icon nearly invisible against the dark card. Here the icon
+                                // just names the category; its brightness carries no information.
+                                .foregroundColor(Color(Colors.mainMagenta))
                                 .frame(width: 24, height: 24)
                         }
                         centerLabel(allocation.category.displayName)

--- a/Finova/Sources/SwiftUI/Charts/BudgetDonutChartView.swift
+++ b/Finova/Sources/SwiftUI/Charts/BudgetDonutChartView.swift
@@ -18,11 +18,18 @@ struct BudgetDonutChartView: View {
     /// Slice order and, when tags exist, the inner ring. Always built by the caller from the same
     /// values as the properties above, so it is never out of step with them.
     var breakdown: AllocationTagBreakdown = .empty
+    var selectedTagId: String?
     var isValuesHidden: Bool = false
     var onSegmentTapped: ((TransactionCategory) -> Void)?
     var onUnallocatedSpendingTapped: ((UnallocatedCategorySpending) -> Void)?
+    /// `nil` clears the tag filter.
+    var onTagSelected: ((String?) -> Void)?
 
     @State private var rawSelectedValue: Int?
+    /// The plot rect, captured so a tap's radius can be measured. `chartAngleSelection` yields only a
+    /// scalar on the angular axis and so cannot tell the two rings apart; the radius is what does.
+    @State private var plotRect: CGRect = .zero
+    @State private var lastTapLocation: CGPoint?
     /// The selected slice's `AllocationTagBreakdown.Segment.id`, or nil.
     ///
     /// Replaced the old integer index, which walked `allocations` in array order and used -1 as a
@@ -139,12 +146,21 @@ struct BudgetDonutChartView: View {
     }
 
     private func opacity(for segment: AllocationTagBreakdown.Segment) -> Double {
-        guard let selectedSegmentID else { return baseOpacity(for: segment) }
-        if segment.id == selectedSegmentID {
-            // Headroom brightens on selection; the other kinds are already at their base.
-            return segment.kind == .headroom ? 1.0 : baseOpacity(for: segment)
+        // A drilled-in slice takes precedence over a selected tag, so tapping a member of the selected
+        // tag still reads as a selection rather than being flattened by it.
+        if let selectedSegmentID {
+            if segment.id == selectedSegmentID {
+                // Headroom brightens on selection; the other kinds are already at their base.
+                return segment.kind == .headroom ? 1.0 : baseOpacity(for: segment)
+            }
+            return 0.35
         }
-        return 0.35
+        if let selectedTagId {
+            // Headroom belongs to no tag, so it is always dimmed while one is selected.
+            guard segment.kind != .headroom else { return 0.35 }
+            return segment.tagId == selectedTagId ? baseOpacity(for: segment) : 0.28
+        }
+        return baseOpacity(for: segment)
     }
 
     /// Geometry of the category ring.
@@ -214,30 +230,68 @@ struct BudgetDonutChartView: View {
                         .frame(width: centerSize, height: centerSize)
                         .position(x: frame.midX, y: frame.midY)
                 }
+                .onAppear { plotRect = frame }
+                .onChange(of: frame) { _, newValue in plotRect = newValue }
             }
         }
+        // `simultaneousGesture`, so this coexists with Charts' own selection recogniser rather than
+        // replacing it: the angle comes from Charts and only the radius comes from here.
+        .simultaneousGesture(
+            SpatialTapGesture(coordinateSpace: .local)
+                .onEnded { event in lastTapLocation = event.location }
+        )
         .onChange(of: rawSelectedValue) { _, newValue in
             withAnimation(.easeInOut(duration: 0.15)) {
                 guard let value = newValue else {
                     selectedSegmentID = nil
                     return
                 }
-                guard let segment = segment(atAngularValue: value) else {
-                    selectedSegmentID = nil
-                    return
-                }
-                selectedSegmentID = segment.id
-                switch segment.kind {
-                case .allocated(let key):
-                    if let allocation = allocationsByCategoryKey[key] {
-                        onSegmentTapped?(allocation.category)
-                    }
-                case .offPlan, .headroom:
-                    // Off-plan and headroom slices only update the centre readout, as before.
-                    break
-                }
+                handleSelection(angularValue: value)
             }
         }
+    }
+
+    private func handleSelection(angularValue: Int) {
+        // Without a tap location there is no radius, so fall back to the outer ring - which is what the
+        // chart did before the tag ring existed.
+        let hit: Hit
+        if let tap = lastTapLocation, plotRect != .zero, hasTags {
+            hit = Self.resolve(
+                tap: tap, plot: plotRect, rawAngleValue: angularValue,
+                breakdown: breakdownForHitTesting)
+        } else if let segment = segment(atAngularValue: angularValue) {
+            hit = .segment(segment.id)
+        } else {
+            hit = .none
+        }
+
+        switch hit {
+        case .tag(let tagId):
+            // Tap-again clears, matching the chip strip.
+            selectedSegmentID = nil
+            onTagSelected?(selectedTagId == tagId ? nil : tagId)
+
+        case .segment(let segmentID):
+            guard let segment = segments.first(where: { $0.id == segmentID }) else { return }
+            // While a tag is selected its non-members are dimmed and out of scope, so a tap on one is
+            // ignored rather than silently drilling into something the user cannot see.
+            if let selectedTagId, segment.tagId != selectedTagId { return }
+            selectedSegmentID = segment.id
+            if case .allocated(let key) = segment.kind,
+                let allocation = allocationsByCategoryKey[key]
+            {
+                onSegmentTapped?(allocation.category)
+            }
+
+        case .none:
+            selectedSegmentID = nil
+        }
+    }
+
+    /// The breakdown `resolve` should walk. Uses the caller's when it has segments, and otherwise the
+    /// tagless one built here, so hit-testing can never disagree with what was drawn.
+    private var breakdownForHitTesting: AllocationTagBreakdown {
+        breakdown.segments.isEmpty ? .empty : breakdown
     }
 
     // MARK: - Tag ring
@@ -277,6 +331,7 @@ struct BudgetDonutChartView: View {
                     path.closeSubpath()
                 }
                 .fill(Color(arc.tag.color.arc))
+                .opacity(selectedTagId == nil || selectedTagId == arc.id ? 1.0 : 0.35)
             }
         }
     }
@@ -318,6 +373,30 @@ struct BudgetDonutChartView: View {
                         .foregroundColor(Color(Colors.gray400))
                     centerLabel("budget.unallocated".localized)
                     centerValue(effectiveUnallocatedAmount)
+                }
+            } else if let arc = selectedArc {
+                if let icon = arc.tag.icon.image {
+                    Image(uiImage: icon)
+                        .resizable()
+                        .renderingMode(.template)
+                        .foregroundColor(Color(arc.tag.color.arc))
+                        .frame(width: 24, height: 24)
+                }
+                centerLabel(arc.tag.name)
+                centerValue(arc.bucket.allocated)
+                // The share is a proportion, not an amount, so it survives value-hiding - the same rule
+                // the projection bar follows. Omitted entirely when there is no budget to be a share of,
+                // rather than printing a meaningless 0%.
+                if totalBudget > 0 {
+                    Text(
+                        String(
+                            format: "budget.tag.shareOfBudget".localized,
+                            Int((arc.bucket.share * 100).rounded()))
+                    )
+                    .font(.system(size: 9))
+                    .foregroundColor(Color(Colors.gray400))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.7)
                 }
             } else if !hasContent {
                 // No allocations or spending - show 0% allocated
@@ -366,6 +445,11 @@ struct BudgetDonutChartView: View {
         return segments.first { $0.id == selectedSegmentID }
     }
 
+    private var selectedArc: AllocationTagBreakdown.TagArc? {
+        guard let selectedTagId else { return nil }
+        return breakdown.arc(id: selectedTagId)
+    }
+
     /// Walks the drawn order accumulating amounts, so the slice returned is the one under the finger
     /// even though that order is no longer the order of the `allocations` array.
     private func segment(atAngularValue value: Int) -> AllocationTagBreakdown.Segment? {
@@ -375,5 +459,56 @@ struct BudgetDonutChartView: View {
             if value <= cumulative { return segment }
         }
         return nil
+    }
+
+    /// What a tap landed on.
+    enum Hit: Equatable {
+        case tag(String)
+        case segment(String)
+        case none
+    }
+
+    /// Radius band a tap must fall in to count as the tag ring: the drawn 55...62pt band widened 4pt
+    /// each way for fingers, still strictly inside the category ring's 66pt inner edge.
+    static let tagBandInnerRadius: CGFloat = 51
+    static let tagBandOuterRadius: CGFloat = 66
+
+    /// Resolves a tap into a ring and a slice. Static and pure so it is testable without SwiftUI.
+    ///
+    /// - Parameters:
+    ///   - tap: point in the plot's coordinate space.
+    ///   - plot: the plot rect, as `.chartBackground` reports it.
+    ///   - rawAngleValue: the value `chartAngleSelection` produced for the same tap.
+    static func resolve(
+        tap: CGPoint,
+        plot: CGRect,
+        rawAngleValue: Int,
+        breakdown: AllocationTagBreakdown
+    ) -> Hit {
+        guard plot.width > 0, plot.height > 0 else { return .none }
+
+        let plotRadius = min(plot.width, plot.height) / 2
+        let scale = plotRadius / 85.0
+        let radius = hypot(tap.x - plot.midX, tap.y - plot.midY)
+
+        // The centre hole. Today a tap here still selects whichever slice shares its angle, which is a
+        // small pre-existing wart; ignoring it is deliberate, not a regression.
+        if radius < tagBandInnerRadius * scale { return .none }
+
+        if radius <= tagBandOuterRadius * scale {
+            guard breakdown.angularTotal > 0 else { return .none }
+            let fraction = Double(rawAngleValue) / Double(breakdown.angularTotal)
+            let arc = breakdown.tagArcs.first {
+                $0.startFraction <= fraction && fraction < $0.endFraction
+            }
+            return arc.map { .tag($0.id) } ?? .none
+        }
+
+        var cumulative = 0
+        for segment in breakdown.segments {
+            cumulative += segment.amount
+            if rawAngleValue <= cumulative { return .segment(segment.id) }
+        }
+        return .none
     }
 }

--- a/Finova/Sources/SwiftUI/Charts/BudgetDonutChartView.swift
+++ b/Finova/Sources/SwiftUI/Charts/BudgetDonutChartView.swift
@@ -5,8 +5,8 @@
 //  Created by Arthur Rios on 02/02/26.
 //
 
-import SwiftUI
 import Charts
+import SwiftUI
 import UIKit
 
 @available(iOS 17.0, *)
@@ -15,12 +15,20 @@ struct BudgetDonutChartView: View {
     let totalBudget: Int
     let unallocatedAmount: Int
     let unallocatedSpending: [UnallocatedCategorySpending]
+    /// Slice order and, when tags exist, the inner ring. Always built by the caller from the same
+    /// values as the properties above, so it is never out of step with them.
+    var breakdown: AllocationTagBreakdown = .empty
     var isValuesHidden: Bool = false
     var onSegmentTapped: ((TransactionCategory) -> Void)?
     var onUnallocatedSpendingTapped: ((UnallocatedCategorySpending) -> Void)?
 
     @State private var rawSelectedValue: Int?
-    @State private var selectedIndex: Int?
+    /// The selected slice's `AllocationTagBreakdown.Segment.id`, or nil.
+    ///
+    /// Replaced the old integer index, which walked `allocations` in array order and used -1 as a
+    /// sentinel for the headroom slice. Once slices are drawn in tag-grouped order rather than array
+    /// order, an index into `allocations` no longer identifies the slice under the finger.
+    @State private var selectedSegmentID: String?
 
     /// Sum of all allocation amounts
     private var allocatedTotal: Int {
@@ -42,52 +50,40 @@ struct BudgetDonutChartView: View {
         allocatedTotal + effectiveUnallocatedAmount + unallocatedSpendingTotal
     }
 
-    private var hasAllocations: Bool {
-        !allocations.isEmpty
+    /// Check if we have any content to display
+    private var hasContent: Bool {
+        !allocations.isEmpty || !unallocatedSpending.isEmpty
     }
 
-    private var allocatedPercentage: Int {
-        guard totalAmount > 0 else { return 0 }
-        return Int((Double(allocatedTotal) / Double(totalAmount)) * 100)
+    /// Whether the inner tag ring is drawn. When false every radius and colour below is exactly what
+    /// the card rendered before tags existed.
+    private var hasTags: Bool { breakdown.hasTags }
+
+    // MARK: - Lookups
+
+    private var allocationsByCategoryKey: [String: BudgetAllocation] {
+        Dictionary(allocations.map { ($0.category.key, $0) }, uniquingKeysWith: { first, _ in first })
     }
 
-    private func findSelectedIndex(for value: Int) -> Int? {
-        var cumulative = 0
-
-        // Check allocations first
-        for (index, allocation) in allocations.enumerated() {
-            cumulative += allocation.allocatedAmount
-            if value <= cumulative {
-                return index
-            }
-        }
-
-        // Check unallocated spending segments
-        // Index will be: allocations.count + spending index
-        for (index, spending) in unallocatedSpending.enumerated() {
-            cumulative += spending.spentAmount
-            if value <= cumulative {
-                return allocations.count + index // Offset by allocations count
-            }
-        }
-
-        // Check if it's the remaining unallocated section
-        if effectiveUnallocatedAmount > 0 && value <= cumulative + effectiveUnallocatedAmount {
-            return -1 // -1 represents remaining unallocated budget
-        }
-        return nil
+    private var spendingByCategoryKey: [String: UnallocatedCategorySpending] {
+        Dictionary(
+            unallocatedSpending.map { ($0.category.key, $0) }, uniquingKeysWith: { first, _ in first })
     }
 
-    /// Check if index is an unallocated spending index
-    private func isUnallocatedSpendingIndex(_ index: Int) -> Bool {
-        return index >= allocations.count && index < allocations.count + unallocatedSpending.count
-    }
-
-    /// Get unallocated spending for a given index
-    private func getUnallocatedSpending(for index: Int) -> UnallocatedCategorySpending? {
-        let spendingIndex = index - allocations.count
-        guard spendingIndex >= 0 && spendingIndex < unallocatedSpending.count else { return nil }
-        return unallocatedSpending[spendingIndex]
+    /// The slices to draw, in draw order.
+    ///
+    /// Falls back to the pre-tag order when no breakdown was supplied, so a caller that passes none -
+    /// the layout tests, and any code path not yet updated - renders exactly as before.
+    private var segments: [AllocationTagBreakdown.Segment] {
+        if !breakdown.segments.isEmpty { return breakdown.segments }
+        return AllocationTagBreakdown(
+            allocations: allocations,
+            unallocatedSpending: unallocatedSpending,
+            unallocatedHeadroom: unallocatedAmount,
+            totalBudget: totalBudget,
+            tags: [],
+            categoryTagIds: [:]
+        ).segments
     }
 
     /// Maximum allocated amount among all allocations (for relative brightness calculation)
@@ -120,54 +116,74 @@ struct BudgetDonutChartView: View {
         return Color(adjustedColor)
     }
 
-    /// Formats currency with ultra-compact notation for chart center
-    private func compactCurrency(_ amount: Int) -> String {
-        return amount.compactCurrencyString
+    private func color(for segment: AllocationTagBreakdown.Segment) -> Color {
+        switch segment.kind {
+        case .allocated(let key):
+            guard let allocation = allocationsByCategoryKey[key] else { return Color(Colors.gray600) }
+            return colorForAllocation(allocation)
+        case .offPlan:
+            return Color(Colors.gray500)
+        case .headroom:
+            return Color(Colors.gray600)
+        }
     }
 
-    /// Check if we have any content to display
-    private var hasContent: Bool {
-        !allocations.isEmpty || !unallocatedSpending.isEmpty
+    /// Base opacity when nothing is selected. Kept as separate literals per kind rather than a single
+    /// multiplier: the values are not proportional to each other, they are three independent choices.
+    private func baseOpacity(for segment: AllocationTagBreakdown.Segment) -> Double {
+        switch segment.kind {
+        case .allocated: return 1.0
+        case .offPlan: return 0.8
+        case .headroom: return 0.5
+        }
     }
+
+    private func opacity(for segment: AllocationTagBreakdown.Segment) -> Double {
+        guard let selectedSegmentID else { return baseOpacity(for: segment) }
+        if segment.id == selectedSegmentID {
+            // Headroom brightens on selection; the other kinds are already at their base.
+            return segment.kind == .headroom ? 1.0 : baseOpacity(for: segment)
+        }
+        return 0.35
+    }
+
+    /// Geometry of the category ring.
+    ///
+    /// Without tags this stays the single three-argument `SectorMark` call the card has always used -
+    /// no `outerRadius`, `innerRadius: .ratio(0.65)` - so a user who never makes a tag keeps the exact
+    /// donut they had. With tags it shrinks to 85...66pt to free a band for the tag ring.
+    private var categoryInnerRatio: CGFloat { hasTags ? Self.categoryRingInnerRatio : 0.65 }
+
+    /// 66pt of the 85pt plot radius.
+    static let categoryRingInnerRatio: CGFloat = 0.7765
+    /// The tag ring occupies 62...55pt, drawn as a 7pt band centred on 58.5pt.
+    static let tagRingOuterRadius: CGFloat = 62
+    static let tagRingInnerRadius: CGFloat = 55
 
     var body: some View {
         Chart {
             if hasContent {
-                // Allocated categories (magenta shades)
-                ForEach(Array(allocations.enumerated()), id: \.1.id) { (index: Int, allocation: BudgetAllocation) in
-                    SectorMark(
-                        angle: .value("Amount", allocation.allocatedAmount),
-                        innerRadius: .ratio(0.65),
-                        angularInset: 2
-                    )
-                    .foregroundStyle(colorForAllocation(allocation))
-                    .cornerRadius(4)
-                    .opacity(selectedIndex == nil || selectedIndex == index ? 1.0 : 0.35)
-                }
-
-                // Unallocated spending categories (slightly brighter gray)
-                ForEach(Array(unallocatedSpending.enumerated()), id: \.1.category.key) { (index: Int, spending: UnallocatedCategorySpending) in
-                    let chartIndex = allocations.count + index
-                    SectorMark(
-                        angle: .value("Unallocated Spending", spending.spentAmount),
-                        innerRadius: .ratio(0.65),
-                        angularInset: 2
-                    )
-                    .foregroundStyle(Color(Colors.gray500)) // Brighter than unallocated budget
-                    .cornerRadius(4)
-                    .opacity(selectedIndex == nil || selectedIndex == chartIndex ? 0.8 : 0.35)
-                }
-
-                // Remaining unallocated budget (darkest gray)
-                if effectiveUnallocatedAmount > 0 {
-                    SectorMark(
-                        angle: .value("Unallocated", effectiveUnallocatedAmount),
-                        innerRadius: .ratio(0.65),
-                        angularInset: 2
-                    )
-                    .foregroundStyle(Color(Colors.gray600))
-                    .cornerRadius(4)
-                    .opacity(selectedIndex == nil ? 0.5 : (selectedIndex == -1 ? 1.0 : 0.35))
+                ForEach(segments) { segment in
+                    if hasTags {
+                        SectorMark(
+                            angle: .value("Amount", segment.amount),
+                            innerRadius: .ratio(categoryInnerRatio),
+                            outerRadius: .ratio(1.0),
+                            angularInset: 2
+                        )
+                        .foregroundStyle(color(for: segment))
+                        .cornerRadius(4)
+                        .opacity(opacity(for: segment))
+                    } else {
+                        SectorMark(
+                            angle: .value("Amount", segment.amount),
+                            innerRadius: .ratio(0.65),
+                            angularInset: 2
+                        )
+                        .foregroundStyle(color(for: segment))
+                        .cornerRadius(4)
+                        .opacity(opacity(for: segment))
+                    }
                 }
             } else {
                 // No allocations or spending - show full gray circle
@@ -185,10 +201,95 @@ struct BudgetDonutChartView: View {
             GeometryReader { geometry in
                 let frame = geometry.frame(in: .local)
                 let centerSize = frame.width * 0.5 // 50% of chart width for center content
-                VStack(spacing: 2) {
-                    if let index = selectedIndex, index >= 0, index < allocations.count {
-                        // Allocated category selected
-                        let allocation = allocations[index]
+                ZStack {
+                    // The tag ring is drawn rather than charted. Every SectorMark in one Chart shares a
+                    // single angular scale whose domain is the sum of ALL mark values, so a second set
+                    // of marks summing to the same total collapses both rings to half a circle each -
+                    // verified, not assumed. `.chartBackground`'s GeometryReader hands us the plot rect,
+                    // so a hand-drawn ring shares the marks' coordinate space exactly.
+                    if hasTags {
+                        tagRing(in: frame)
+                    }
+                    centerContent
+                        .frame(width: centerSize, height: centerSize)
+                        .position(x: frame.midX, y: frame.midY)
+                }
+            }
+        }
+        .onChange(of: rawSelectedValue) { _, newValue in
+            withAnimation(.easeInOut(duration: 0.15)) {
+                guard let value = newValue else {
+                    selectedSegmentID = nil
+                    return
+                }
+                guard let segment = segment(atAngularValue: value) else {
+                    selectedSegmentID = nil
+                    return
+                }
+                selectedSegmentID = segment.id
+                switch segment.kind {
+                case .allocated(let key):
+                    if let allocation = allocationsByCategoryKey[key] {
+                        onSegmentTapped?(allocation.category)
+                    }
+                case .offPlan, .headroom:
+                    // Off-plan and headroom slices only update the centre readout, as before.
+                    break
+                }
+            }
+        }
+    }
+
+    // MARK: - Tag ring
+
+    /// One filled annular sector per tag arc.
+    ///
+    /// Filled with hard radial edges, not stroked: `StrokeStyle(lineCap: .round)` on a 7pt band turns
+    /// every arc into a pill, which reads as a different visual language from the category slices
+    /// 4pt outside it. The marks' own `cornerRadius(4)` is not mimicked for the same reason - at 7pt a
+    /// 4pt corner radius is a pill again.
+    @available(iOS 17.0, *)
+    private func tagRing(in frame: CGRect) -> some View {
+        let centre = CGPoint(x: frame.midX, y: frame.midY)
+        let plotRadius = min(frame.width, frame.height) / 2
+        // The ring's radii are expressed against the 85pt design radius, so they hold if the container
+        // is ever sized differently.
+        let scale = plotRadius / 85.0
+        let outer = Self.tagRingOuterRadius * scale
+        let inner = Self.tagRingInnerRadius * scale
+
+        return ZStack {
+            ForEach(breakdown.tagArcs) { arc in
+                let start = -Double.pi / 2 + arc.startFraction * 2 * Double.pi
+                let end = -Double.pi / 2 + arc.endFraction * 2 * Double.pi
+                // The marks' 2pt angularInset converted to radians at this ring's own radius, so the
+                // gaps line up with the outer band's radially instead of just numerically.
+                let inset = min(2.0 / Double(outer), max(0, (end - start) / 2 - 0.001))
+                Path { path in
+                    path.addArc(
+                        center: centre, radius: outer,
+                        startAngle: .radians(start + inset), endAngle: .radians(end - inset),
+                        clockwise: false)
+                    path.addArc(
+                        center: centre, radius: inner,
+                        startAngle: .radians(end - inset), endAngle: .radians(start + inset),
+                        clockwise: true)
+                    path.closeSubpath()
+                }
+                .fill(Color(arc.tag.color.arc))
+            }
+        }
+    }
+
+    // MARK: - Centre readout
+
+    @ViewBuilder
+    private var centerContent: some View {
+        VStack(spacing: 2) {
+            if let selected = selectedSegment {
+                switch selected.kind {
+                case .allocated(let key):
+                    if let allocation = allocationsByCategoryKey[key] {
                         if let icon = UIImage(named: allocation.category.iconName) {
                             Image(uiImage: icon)
                                 .resizable()
@@ -196,18 +297,11 @@ struct BudgetDonutChartView: View {
                                 .foregroundColor(colorForAllocation(allocation))
                                 .frame(width: 24, height: 24)
                         }
-                        Text(allocation.category.displayName)
-                            .font(.system(size: 10, weight: .medium))
-                            .foregroundColor(Color(Colors.gray300))
-                            .lineLimit(1)
-                            .minimumScaleFactor(0.8)
-                        Text(isValuesHidden ? "••••••" : compactCurrency(allocation.allocatedAmount))
-                            .font(.system(size: 14, weight: .bold))
-                            .foregroundColor(Color(Colors.gray100))
-                            .lineLimit(1)
-                            .minimumScaleFactor(0.6)
-                    } else if let index = selectedIndex, let spending = getUnallocatedSpending(for: index) {
-                        // Unallocated spending category selected
+                        centerLabel(allocation.category.displayName)
+                        centerValue(allocation.allocatedAmount)
+                    }
+                case .offPlan(let key):
+                    if let spending = spendingByCategoryKey[key] {
                         if let icon = UIImage(named: spending.category.iconName(for: .expense)) {
                             Image(uiImage: icon)
                                 .resizable()
@@ -215,73 +309,71 @@ struct BudgetDonutChartView: View {
                                 .foregroundColor(Color(Colors.gray400))
                                 .frame(width: 24, height: 24)
                         }
-                        Text(spending.category.displayName)
-                            .font(.system(size: 10, weight: .medium))
-                            .foregroundColor(Color(Colors.gray300))
-                            .lineLimit(1)
-                            .minimumScaleFactor(0.8)
-                        Text(isValuesHidden ? "••••••" : compactCurrency(spending.spentAmount))
-                            .font(.system(size: 14, weight: .bold))
-                            .foregroundColor(Color(Colors.gray100))
-                            .lineLimit(1)
-                            .minimumScaleFactor(0.6)
-                    } else if selectedIndex == -1 {
-                        // Remaining unallocated budget selected
-                        Image(systemName: "questionmark.circle")
-                            .font(.system(size: 24))
-                            .foregroundColor(Color(Colors.gray400))
-                        Text("budget.unallocated".localized)
-                            .font(.system(size: 10, weight: .medium))
-                            .foregroundColor(Color(Colors.gray300))
-                            .lineLimit(1)
-                            .minimumScaleFactor(0.8)
-                        Text(isValuesHidden ? "••••••" : compactCurrency(effectiveUnallocatedAmount))
-                            .font(.system(size: 14, weight: .bold))
-                            .foregroundColor(Color(Colors.gray100))
-                            .lineLimit(1)
-                            .minimumScaleFactor(0.6)
-                    } else if !hasContent {
-                        // No allocations or spending - show 0% allocated
-                        Text("0%")
-                            .font(.system(size: 16, weight: .bold))
-                            .foregroundColor(Color(Colors.gray400))
-                            .lineLimit(1)
-                            .minimumScaleFactor(0.6)
-                        Text("budget.allocated.label".localized)
-                            .font(.system(size: 11))
-                            .foregroundColor(Color(Colors.gray500))
-                    } else {
-                        // Show total budget
-                        Text(isValuesHidden ? "••••••" : compactCurrency(totalBudget))
-                            .font(.system(size: 16, weight: .bold))
-                            .foregroundColor(Color(Colors.gray100))
-                            .lineLimit(1)
-                            .minimumScaleFactor(0.6)
-                        Text("budget.total.label".localized)
-                            .font(.system(size: 11))
-                            .foregroundColor(Color(Colors.gray400))
+                        centerLabel(spending.category.displayName)
+                        centerValue(spending.spentAmount)
                     }
+                case .headroom:
+                    Image(systemName: "questionmark.circle")
+                        .font(.system(size: 24))
+                        .foregroundColor(Color(Colors.gray400))
+                    centerLabel("budget.unallocated".localized)
+                    centerValue(effectiveUnallocatedAmount)
                 }
-                .frame(width: centerSize, height: centerSize)
-                .position(x: frame.midX, y: frame.midY)
+            } else if !hasContent {
+                // No allocations or spending - show 0% allocated
+                Text("0%")
+                    .font(.system(size: 16, weight: .bold))
+                    .foregroundColor(Color(Colors.gray400))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.6)
+                Text("budget.allocated.label".localized)
+                    .font(.system(size: 11))
+                    .foregroundColor(Color(Colors.gray500))
+            } else {
+                // Show total budget
+                Text(isValuesHidden ? "••••••" : totalBudget.compactCurrencyString)
+                    .font(.system(size: 16, weight: .bold))
+                    .foregroundColor(Color(Colors.gray100))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.6)
+                Text("budget.total.label".localized)
+                    .font(.system(size: 11))
+                    .foregroundColor(Color(Colors.gray400))
             }
         }
-        .onChange(of: rawSelectedValue) { _, newValue in
-            withAnimation(.easeInOut(duration: 0.15)) {
-                if let value = newValue {
-                    selectedIndex = findSelectedIndex(for: value)
-                    if let index = selectedIndex {
-                        if index >= 0 && index < allocations.count {
-                            // Allocated category tapped
-                            onSegmentTapped?(allocations[index].category)
-                        }
-                        // Unallocated spending and remaining budget segments
-                        // only update the center display via selectedIndex
-                    }
-                } else {
-                    selectedIndex = nil
-                }
-            }
+    }
+
+    private func centerLabel(_ text: String) -> some View {
+        Text(text)
+            .font(.system(size: 10, weight: .medium))
+            .foregroundColor(Color(Colors.gray300))
+            .lineLimit(1)
+            .minimumScaleFactor(0.8)
+    }
+
+    private func centerValue(_ amount: Int) -> some View {
+        Text(isValuesHidden ? "••••••" : amount.compactCurrencyString)
+            .font(.system(size: 14, weight: .bold))
+            .foregroundColor(Color(Colors.gray100))
+            .lineLimit(1)
+            .minimumScaleFactor(0.6)
+    }
+
+    // MARK: - Hit testing
+
+    private var selectedSegment: AllocationTagBreakdown.Segment? {
+        guard let selectedSegmentID else { return nil }
+        return segments.first { $0.id == selectedSegmentID }
+    }
+
+    /// Walks the drawn order accumulating amounts, so the slice returned is the one under the finger
+    /// even though that order is no longer the order of the `allocations` array.
+    private func segment(atAngularValue value: Int) -> AllocationTagBreakdown.Segment? {
+        var cumulative = 0
+        for segment in segments {
+            cumulative += segment.amount
+            if value <= cumulative { return segment }
         }
+        return nil
     }
 }

--- a/FinovaTests/AllocationBalanceProjectionTests.swift
+++ b/FinovaTests/AllocationBalanceProjectionTests.swift
@@ -28,22 +28,24 @@ final class AllocationBalanceProjectionTests: XCTestCase {
         )
     }
 
-    /// The two bar segments must always describe a whole, or nothing at all - the bar fills the
-    /// width once anything has been spent, so the comparison stays readable.
+    /// The three bar segments must always describe a whole, or nothing at all - the bar fills the
+    /// width whenever there is something to divide, so the comparison stays readable.
     private func assertSharesNormalised(
         _ projection: AllocationBalanceProjection,
         line: UInt = #line
     ) {
         let shares = projection.barShares
-        let sum = shares.withinPlan + shares.beyondPlan
+        let sum = shares.projected + shares.saved + shares.overspent
         if sum == 0 {
-            XCTAssertEqual(shares.withinPlan, 0, line: line)
-            XCTAssertEqual(shares.beyondPlan, 0, line: line)
+            XCTAssertEqual(shares.projected, 0, line: line)
+            XCTAssertEqual(shares.saved, 0, line: line)
+            XCTAssertEqual(shares.overspent, 0, line: line)
         } else {
             XCTAssertEqual(sum, 1.0, accuracy: 0.0001, line: line)
         }
-        XCTAssertGreaterThanOrEqual(shares.withinPlan, 0, line: line)
-        XCTAssertGreaterThanOrEqual(shares.beyondPlan, 0, line: line)
+        XCTAssertGreaterThanOrEqual(shares.projected, 0, line: line)
+        XCTAssertGreaterThanOrEqual(shares.saved, 0, line: line)
+        XCTAssertGreaterThanOrEqual(shares.overspent, 0, line: line)
     }
 
     // MARK: - Projection arithmetic
@@ -286,63 +288,81 @@ final class AllocationBalanceProjectionTests: XCTestCase {
 
     // MARK: - Bar
 
-    /// The bar compares *spent* money, not saved money: an open month cannot have saved anything,
-    /// so a bar built from `totalSaved` would erode as the month filled in.
-    func testBarComparesSpendingInsideThePlanAgainstSpendingOutsideIt() {
+    /// The bar compares the block's three quantities: what the balance ends up with, what is being
+    /// saved, and what broke out of the plan.
+    func testBarComparesProjectedAgainstSavedAndOverspent() {
+        // R$4k balance, R$1k allocated with R$400 of it spent: R$600 unspent, so R$3.4k survives.
         let projection = AllocationBalanceProjection(
             base: 400_000,
-            allocations: [allocation(.meals, allocated: 100_000, used: 75_000)],
-            unallocatedSpending: 25_000,
+            allocations: [allocation(.meals, allocated: 100_000, used: 40_000)],
+            unallocatedHeadroom: 20_000,
             tense: .projected)
 
-        XCTAssertEqual(projection.usedWithinAllocations, 75_000)
-        XCTAssertEqual(projection.overspent, 25_000)
-        XCTAssertEqual(projection.barShares.withinPlan, 0.75, accuracy: 0.0001)
-        XCTAssertEqual(projection.barShares.beyondPlan, 0.25, accuracy: 0.0001)
+        XCTAssertEqual(projection.projected, 340_000)
+        XCTAssertEqual(projection.totalSaved, 80_000)  // 60_000 unspent + 20_000 headroom
+        XCTAssertEqual(projection.overspent, 0)
+
+        let shares = projection.barShares
+        XCTAssertEqual(shares.projected, 340_000 / 420_000, accuracy: 0.0001)
+        XCTAssertEqual(shares.saved, 80_000 / 420_000, accuracy: 0.0001)
+        XCTAssertEqual(shares.overspent, 0)
         assertSharesNormalised(projection)
     }
 
-    func testBarIsAllGreenWhenEverySpendStayedInsideItsAllocation() {
+    /// The regression that prompted the three-segment bar: `projected` is what is left *after* savings
+    /// come out, so it must never wear the colour that means "saved". Here the projection dwarfs the
+    /// saved figure, and if the two were merged - or if projected took the green - the bar would claim
+    /// almost everything is being kept.
+    func testProjectedIsNotTheSavedAmount() {
         let projection = AllocationBalanceProjection(
             base: 400_000,
-            allocations: [allocation(.meals, allocated: 100_000, used: 60_000)],
+            allocations: [allocation(.savings, allocated: 50_000, used: 50_000)],
             tense: .projected)
 
-        XCTAssertEqual(projection.barShares.withinPlan, 1.0, accuracy: 0.0001)
-        XCTAssertEqual(projection.barShares.beyondPlan, 0)
-    }
-
-    func testBarIsEmptyBeforeAnythingIsSpent() {
-        // A future month with allocations but no transactions yet: nothing to compare.
-        let projection = AllocationBalanceProjection(
-            base: 400_000,
-            allocations: [allocation(.meals, allocated: 100_000, used: 0)],
-            unallocatedHeadroom: 73_500,
-            tense: .projected)
-
-        XCTAssertEqual(projection.barShares.withinPlan, 0)
-        XCTAssertEqual(projection.barShares.beyondPlan, 0)
-        assertSharesNormalised(projection)
-    }
-
-    /// Regression for the real complaint: a future month's unspent allocations must not inflate the
-    /// bar, because that money is earmarked for spending, not kept.
-    func testUnspentAllocationsDoNotInflateTheBar() {
-        // R$3.5k of allocations untouched, R$735 unallocated - nothing spent at all.
-        let untouched = AllocationBalanceProjection(
-            base: 4_290_000,
-            allocations: [allocation(.market, allocated: 350_000, used: 0)],
-            unallocatedHeadroom: 73_500,
-            tense: .projected)
-
+        XCTAssertEqual(projection.projected, 400_000, "a fully funded allocation is already out")
         XCTAssertEqual(
-            untouched.barShares.withinPlan, 0,
-            "a plan nobody has spent against yet says nothing about adherence")
-        XCTAssertGreaterThan(
-            untouched.totalSaved, 0,
-            "totalSaved still tracks it - the card just does not surface it while the month is open")
+            projection.totalSaved, 0,
+            "money paid into a savings category left the account; it is not held")
+        XCTAssertEqual(projection.barShares.projected, 1.0, accuracy: 0.0001)
+        XCTAssertEqual(projection.barShares.saved, 0)
     }
 
+    func testOverspendingGetsItsOwnSegment() {
+        let projection = AllocationBalanceProjection(
+            base: 300_000,
+            allocations: [allocation(.meals, allocated: 100_000, used: 130_000)],
+            unallocatedSpending: 20_000,
+            tense: .projected)
+
+        XCTAssertEqual(projection.overspent, 50_000)  // 30_000 overrun + 20_000 off-plan
+        XCTAssertGreaterThan(projection.barShares.overspent, 0)
+        assertSharesNormalised(projection)
+    }
+
+    /// An over-committed month cannot draw a negative width. The shortfall is named in the block's
+    /// caption instead, so the bar shows only the quantities that do have a size.
+    func testOverCommittedBarDropsTheProjectedSegment() {
+        let projection = AllocationBalanceProjection(
+            base: 50_000,
+            allocations: [allocation(.meals, allocated: 200_000, used: 0)],
+            tense: .projected)
+
+        XCTAssertTrue(projection.isOverCommitted)
+        XCTAssertEqual(projection.barShares.projected, 0)
+        XCTAssertEqual(projection.barShares.saved, 1.0, accuracy: 0.0001)
+        assertSharesNormalised(projection)
+    }
+
+    func testBarIsEmptyWhenThereIsNothingToCompare() {
+        let projection = AllocationBalanceProjection(base: 0, allocations: [], tense: .projected)
+
+        XCTAssertEqual(projection.barShares.projected, 0)
+        XCTAssertEqual(projection.barShares.saved, 0)
+        XCTAssertEqual(projection.barShares.overspent, 0)
+        assertSharesNormalised(projection)
+    }
+
+    /// Both tenses read the same three quantities, so "saved" means one thing across the whole card.
     func testBarIsTenseIndependent() {
         let allocations = [
             allocation(.meals, allocated: 100_000, used: 25_000),
@@ -354,8 +374,9 @@ final class AllocationBalanceProjectionTests: XCTestCase {
         let actual = AllocationBalanceProjection(
             base: 400_000, allocations: allocations, tense: .actual)
 
-        XCTAssertEqual(projected.barShares.withinPlan, actual.barShares.withinPlan, accuracy: 0.0001)
-        XCTAssertEqual(projected.barShares.beyondPlan, actual.barShares.beyondPlan, accuracy: 0.0001)
+        XCTAssertEqual(projected.barShares.projected, actual.barShares.projected, accuracy: 0.0001)
+        XCTAssertEqual(projected.barShares.saved, actual.barShares.saved, accuracy: 0.0001)
+        XCTAssertEqual(projected.barShares.overspent, actual.barShares.overspent, accuracy: 0.0001)
     }
 
     // MARK: - Closed-month headline

--- a/FinovaTests/AllocationTagBreakdownTests.swift
+++ b/FinovaTests/AllocationTagBreakdownTests.swift
@@ -1,0 +1,401 @@
+//
+//  AllocationTagBreakdownTests.swift
+//  FinovaTests
+//
+//  Per-tag subtotals and the donut's segment order, on the allocations card.
+//
+
+import Foundation
+import XCTest
+
+@testable import Finova
+
+final class AllocationTagBreakdownTests: XCTestCase {
+
+    private let anchor = 1_767_225_600  // arbitrary; the type never reads a date
+
+    // MARK: - Fixtures
+
+    private func allocation(
+        _ category: TransactionCategory,
+        allocated: Int,
+        used: Int = 0
+    ) -> BudgetAllocation {
+        BudgetAllocation(
+            dbId: nil,
+            monthDate: anchor,
+            category: category,
+            allocatedAmount: allocated,
+            usedAmount: used)
+    }
+
+    private func spending(
+        _ category: TransactionCategory,
+        spent: Int
+    ) -> UnallocatedCategorySpending {
+        UnallocatedCategorySpending(category: category, spentAmount: spent, monthDate: anchor)
+    }
+
+    private func tag(_ id: String, _ name: String, order: Int) -> AllocationTag {
+        AllocationTag(id: id, name: name, colorIndex: order, sortOrder: order)
+    }
+
+    private let essentials = AllocationTag(
+        id: "t-essentials", name: "Essentials", colorIndex: 0, sortOrder: 0)
+    private let wealth = AllocationTag(id: "t-wealth", name: "Wealth", colorIndex: 1, sortOrder: 1)
+
+    /// The scenario from the design discussion: investments dominate the plan, and the living costs
+    /// worth tracking sit inside what is left.
+    private func makeStandardBreakdown() -> AllocationTagBreakdown {
+        AllocationTagBreakdown(
+            allocations: [
+                allocation(.investments, allocated: 560_000, used: 560_000),
+                allocation(.homeMaintenance, allocated: 200_000, used: 200_000),
+                allocation(.groceries, allocated: 60_000, used: 48_000),
+                allocation(.transportation, allocated: 40_000, used: 31_000),
+                allocation(.utilities, allocated: 30_000, used: 27_500),
+            ],
+            unallocatedSpending: [],
+            unallocatedHeadroom: 110_000,
+            totalBudget: 1_000_000,
+            tags: [essentials, wealth],
+            categoryTagIds: [
+                TransactionCategory.investments.key: wealth.id,
+                TransactionCategory.homeMaintenance.key: essentials.id,
+                TransactionCategory.groceries.key: essentials.id,
+                TransactionCategory.transportation.key: essentials.id,
+                TransactionCategory.utilities.key: essentials.id,
+            ])
+    }
+
+    // MARK: - Subtotals
+
+    func testTagAllocatedIsTheSumOfItsMemberAllocations() {
+        let breakdown = makeStandardBreakdown()
+
+        // 200_000 + 60_000 + 40_000 + 30_000
+        XCTAssertEqual(breakdown.arc(id: essentials.id)?.bucket.allocated, 330_000)
+        XCTAssertEqual(breakdown.arc(id: wealth.id)?.bucket.allocated, 560_000)
+    }
+
+    func testTagUsedIncludesEveryMemberSpend() {
+        let breakdown = makeStandardBreakdown()
+
+        // 200_000 + 48_000 + 31_000 + 27_500
+        XCTAssertEqual(breakdown.arc(id: essentials.id)?.bucket.used, 306_500)
+        XCTAssertEqual(breakdown.arc(id: essentials.id)?.bucket.remaining, 23_500)
+    }
+
+    func testShareIsMeasuredAgainstTheMonthsBudget() {
+        let breakdown = makeStandardBreakdown()
+
+        XCTAssertEqual(breakdown.arc(id: essentials.id)?.bucket.share ?? 0, 0.33, accuracy: 0.0001)
+        XCTAssertEqual(breakdown.arc(id: wealth.id)?.bucket.share ?? 0, 0.56, accuracy: 0.0001)
+    }
+
+    /// Off-plan spend has no plan behind it, so it must not inflate a sub-budget - it lands in `used`
+    /// and `offPlan`, widens the arc, and leaves `allocated` and `share` alone.
+    func testOffPlanSpendWidensTheArcButNotTheSubBudget() {
+        let breakdown = AllocationTagBreakdown(
+            allocations: [allocation(.groceries, allocated: 60_000, used: 48_000)],
+            unallocatedSpending: [spending(.transportation, spent: 25_000)],
+            unallocatedHeadroom: 0,
+            totalBudget: 100_000,
+            tags: [essentials],
+            categoryTagIds: [
+                TransactionCategory.groceries.key: essentials.id,
+                TransactionCategory.transportation.key: essentials.id,
+            ])
+
+        let bucket = breakdown.arc(id: essentials.id)?.bucket
+        XCTAssertEqual(bucket?.allocated, 60_000)
+        XCTAssertEqual(bucket?.offPlan, 25_000)
+        XCTAssertEqual(bucket?.used, 73_000)
+        XCTAssertEqual(bucket?.angularAmount, 85_000)
+        XCTAssertEqual(bucket?.share ?? 0, 0.6, accuracy: 0.0001)
+    }
+
+    /// The figures a tag reports must be the same ones the card computes, or the chip and the
+    /// projection block will disagree about the same month.
+    func testUnspentAndOverspentMatchTheCardsOwnHelpers() {
+        let members = [
+            allocation(.groceries, allocated: 60_000, used: 48_000),
+            allocation(.meals, allocated: 30_000, used: 44_000),
+        ]
+        let breakdown = AllocationTagBreakdown(
+            allocations: members,
+            unallocatedSpending: [],
+            unallocatedHeadroom: 0,
+            totalBudget: 100_000,
+            tags: [essentials],
+            categoryTagIds: [
+                TransactionCategory.groceries.key: essentials.id,
+                TransactionCategory.meals.key: essentials.id,
+            ])
+
+        let bucket = breakdown.arc(id: essentials.id)?.bucket
+        XCTAssertEqual(bucket?.unspent, AllocationBalanceProjection.unspent(allocations: members))
+        XCTAssertEqual(
+            bucket?.overspent,
+            AllocationBalanceProjection.overspent(allocations: members, unallocatedSpending: 0))
+        XCTAssertEqual(bucket?.overspent, 14_000)
+        XCTAssertTrue(bucket?.isOverspent ?? false)
+    }
+
+    // MARK: - Segment order
+
+    func testTagsAreOrderedByTotalDescendingAndMembersStayContiguous() {
+        let breakdown = makeStandardBreakdown()
+
+        XCTAssertEqual(breakdown.tagArcs.map { $0.id }, [wealth.id, essentials.id])
+
+        // Every member of a tag must sit in one unbroken run, or the ring cannot span them.
+        for arc in breakdown.tagArcs {
+            let positions = breakdown.segments.enumerated()
+                .filter { arc.memberSegmentIDs.contains($0.element.id) }
+                .map { $0.offset }
+            XCTAssertEqual(
+                positions, Array(positions.first!...positions.last!),
+                "\(arc.tag.name) members are not contiguous")
+        }
+    }
+
+    func testHeadroomIsAlwaysTheLastSegment() {
+        let breakdown = makeStandardBreakdown()
+
+        XCTAssertEqual(breakdown.segments.last?.kind, .headroom)
+        XCTAssertEqual(breakdown.segments.last?.amount, 110_000)
+        XCTAssertNil(breakdown.segments.last?.tagId)
+    }
+
+    /// With no tags the donut must draw exactly what it drew before this feature existed: allocations
+    /// by amount descending, then off-plan spend by amount descending, then headroom.
+    func testWithoutTagsTheSegmentOrderMatchesTheLegacyOrder() {
+        let breakdown = AllocationTagBreakdown(
+            allocations: [
+                allocation(.groceries, allocated: 60_000),
+                allocation(.investments, allocated: 560_000),
+                allocation(.utilities, allocated: 30_000),
+            ],
+            unallocatedSpending: [spending(.meals, spent: 12_000), spending(.travel, spent: 40_000)],
+            unallocatedHeadroom: 50_000,
+            totalBudget: 1_000_000,
+            tags: [],
+            categoryTagIds: [:])
+
+        XCTAssertFalse(breakdown.hasTags)
+        XCTAssertTrue(breakdown.tagArcs.isEmpty)
+        XCTAssertNil(breakdown.untagged)
+        XCTAssertEqual(
+            breakdown.segments.map { $0.id },
+            [
+                "alloc-investments", "alloc-groceries", "alloc-utilities",
+                "offplan-travel", "offplan-meals",
+                "headroom",
+            ])
+    }
+
+    /// Same requirement as above, reached the other way: a user who made tags but has not linked any
+    /// category yet must still see the untouched card.
+    func testTagsThatMatchNothingThisMonthChangeNothing() {
+        let breakdown = AllocationTagBreakdown(
+            allocations: [allocation(.groceries, allocated: 60_000)],
+            unallocatedSpending: [],
+            unallocatedHeadroom: 0,
+            totalBudget: 100_000,
+            tags: [essentials, wealth],
+            categoryTagIds: [TransactionCategory.travel.key: essentials.id])
+
+        XCTAssertFalse(breakdown.hasTags)
+        XCTAssertTrue(breakdown.tagArcs.isEmpty)
+        XCTAssertNil(breakdown.untagged, "a lone Untagged chip covering everything is noise")
+        XCTAssertEqual(breakdown.segments.map { $0.id }, ["alloc-groceries"])
+    }
+
+    func testAnIdleTagGetsNoArcAndNoChip() {
+        let breakdown = makeStandardBreakdown()
+
+        let idle = tag("t-idle", "Idle", order: 5)
+        let withIdle = AllocationTagBreakdown(
+            allocations: [allocation(.groceries, allocated: 60_000)],
+            unallocatedSpending: [],
+            unallocatedHeadroom: 0,
+            totalBudget: 100_000,
+            tags: [essentials, idle],
+            categoryTagIds: [TransactionCategory.groceries.key: essentials.id])
+
+        XCTAssertEqual(breakdown.tagArcs.count, 2)
+        XCTAssertEqual(withIdle.tagArcs.map { $0.id }, [essentials.id])
+        XCTAssertNil(withIdle.arc(id: idle.id))
+    }
+
+    // MARK: - Untagged and headroom
+
+    func testUntaggedIsItsOwnBucketOnceSomethingIsTagged() {
+        let breakdown = AllocationTagBreakdown(
+            allocations: [
+                allocation(.groceries, allocated: 60_000, used: 48_000),
+                allocation(.travel, allocated: 25_000, used: 10_000),
+            ],
+            unallocatedSpending: [],
+            unallocatedHeadroom: 15_000,
+            totalBudget: 100_000,
+            tags: [essentials],
+            categoryTagIds: [TransactionCategory.groceries.key: essentials.id])
+
+        XCTAssertEqual(breakdown.untagged?.allocated, 25_000)
+        XCTAssertEqual(breakdown.untagged?.used, 10_000)
+    }
+
+    /// Headroom belongs to no tag *and* to no untagged bucket. Folding it into untagged would make the
+    /// chip disagree with the footer's own "Unallocated" figure.
+    func testHeadroomIsExcludedFromEveryBucket() {
+        let breakdown = AllocationTagBreakdown(
+            allocations: [
+                allocation(.groceries, allocated: 60_000),
+                allocation(.travel, allocated: 25_000),
+            ],
+            unallocatedSpending: [],
+            unallocatedHeadroom: 15_000,
+            totalBudget: 100_000,
+            tags: [essentials],
+            categoryTagIds: [TransactionCategory.groceries.key: essentials.id])
+
+        XCTAssertEqual(breakdown.headroom, 15_000)
+        XCTAssertEqual(breakdown.arc(id: essentials.id)?.bucket.allocated, 60_000)
+        XCTAssertEqual(breakdown.untagged?.allocated, 25_000)
+        XCTAssertEqual(
+            breakdown.tagArcs.reduce(0) { $0 + $1.bucket.allocated } + (breakdown.untagged?.allocated ?? 0),
+            85_000,
+            "headroom must not appear in any bucket's allocated total")
+    }
+
+    func testNegativeHeadroomClampsToZeroAndLeavesTheDomain() {
+        let breakdown = AllocationTagBreakdown(
+            allocations: [allocation(.groceries, allocated: 60_000)],
+            unallocatedSpending: [],
+            unallocatedHeadroom: -20_000,
+            totalBudget: 40_000,
+            tags: [essentials],
+            categoryTagIds: [TransactionCategory.groceries.key: essentials.id])
+
+        XCTAssertEqual(breakdown.headroom, 0)
+        XCTAssertEqual(breakdown.angularTotal, 60_000)
+        XCTAssertFalse(breakdown.segments.contains { $0.kind == .headroom })
+    }
+
+    func testZeroBudgetYieldsNoShareRatherThanADivideByZero() {
+        let breakdown = AllocationTagBreakdown(
+            allocations: [allocation(.groceries, allocated: 60_000)],
+            unallocatedSpending: [],
+            unallocatedHeadroom: 0,
+            totalBudget: 0,
+            tags: [essentials],
+            categoryTagIds: [TransactionCategory.groceries.key: essentials.id])
+
+        XCTAssertEqual(breakdown.arc(id: essentials.id)?.bucket.share, 0)
+        XCTAssertEqual(breakdown.arc(id: essentials.id)?.bucket.allocated, 60_000)
+    }
+
+    func testATagWithOnlyOffPlanSpendStillGetsAnArc() {
+        let breakdown = AllocationTagBreakdown(
+            allocations: [],
+            unallocatedSpending: [spending(.transportation, spent: 25_000)],
+            unallocatedHeadroom: 0,
+            totalBudget: 100_000,
+            tags: [essentials],
+            categoryTagIds: [TransactionCategory.transportation.key: essentials.id])
+
+        let bucket = breakdown.arc(id: essentials.id)?.bucket
+        XCTAssertNotNil(bucket, "the ring geometry needs an arc wherever the donut has slices")
+        XCTAssertEqual(bucket?.allocated, 0)
+        XCTAssertEqual(bucket?.share, 0)
+        XCTAssertEqual(bucket?.angularAmount, 25_000)
+    }
+
+    // MARK: - Invariants
+
+    /// The donut normalises by the sum of every slice, so the ring's fractions are only correct while
+    /// `angularTotal` equals that sum. Drift here shows up as arcs that no longer cap their members.
+    func testAngularTotalIsTheSumOfEverySegment() {
+        for breakdown in [makeStandardBreakdown(), makeMixedBreakdown()] {
+            XCTAssertEqual(
+                breakdown.angularTotal,
+                breakdown.segments.reduce(0) { $0 + $1.amount })
+        }
+    }
+
+    func testBucketAngularAmountsPlusHeadroomAccountForTheWholeDomain() {
+        let breakdown = makeMixedBreakdown()
+
+        let sum =
+            breakdown.tagArcs.reduce(0) { $0 + $1.bucket.angularAmount }
+            + (breakdown.untagged?.angularAmount ?? 0)
+            + breakdown.headroom
+        XCTAssertEqual(sum, breakdown.angularTotal)
+    }
+
+    func testArcFractionsAreMonotoneAndStartAtZero() {
+        let breakdown = makeStandardBreakdown()
+
+        XCTAssertEqual(breakdown.tagArcs.first?.startFraction ?? -1, 0, accuracy: 0.0001)
+        var previousEnd = 0.0
+        for arc in breakdown.tagArcs {
+            XCTAssertEqual(arc.startFraction, previousEnd, accuracy: 0.0001)
+            XCTAssertGreaterThan(arc.endFraction, arc.startFraction)
+            previousEnd = arc.endFraction
+        }
+        XCTAssertLessThanOrEqual(previousEnd, 1.0)
+    }
+
+    func testEverySegmentBelongsToAtMostOneTag() {
+        let breakdown = makeMixedBreakdown()
+
+        for segment in breakdown.segments {
+            let owners = breakdown.tagArcs.filter { $0.memberSegmentIDs.contains(segment.id) }
+            XCTAssertLessThanOrEqual(owners.count, 1, "\(segment.id) is claimed by \(owners.count) tags")
+            XCTAssertEqual(owners.first?.id, segment.tagId)
+        }
+    }
+
+    func testSegmentMembershipLookupAgreesWithTheArcs() {
+        let breakdown = makeStandardBreakdown()
+
+        XCTAssertTrue(breakdown.segment("alloc-groceries", belongsTo: essentials.id))
+        XCTAssertFalse(breakdown.segment("alloc-groceries", belongsTo: wealth.id))
+        XCTAssertFalse(breakdown.segment("headroom", belongsTo: essentials.id))
+    }
+
+    func testEmptyBreakdownIsInert() {
+        let breakdown = AllocationTagBreakdown.empty
+
+        XCTAssertFalse(breakdown.hasTags)
+        XCTAssertTrue(breakdown.segments.isEmpty)
+        XCTAssertNil(breakdown.untagged)
+        XCTAssertEqual(breakdown.angularTotal, 0)
+    }
+
+    /// Everything at once: two tags, an untagged category, off-plan spend on both sides, and headroom.
+    private func makeMixedBreakdown() -> AllocationTagBreakdown {
+        AllocationTagBreakdown(
+            allocations: [
+                allocation(.investments, allocated: 560_000, used: 560_000),
+                allocation(.homeMaintenance, allocated: 200_000, used: 210_000),
+                allocation(.groceries, allocated: 60_000, used: 48_000),
+                allocation(.travel, allocated: 25_000, used: 5_000),
+            ],
+            unallocatedSpending: [
+                spending(.transportation, spent: 31_000),
+                spending(.entertainment, spent: 12_000),
+            ],
+            unallocatedHeadroom: 40_000,
+            totalBudget: 1_000_000,
+            tags: [essentials, wealth],
+            categoryTagIds: [
+                TransactionCategory.investments.key: wealth.id,
+                TransactionCategory.homeMaintenance.key: essentials.id,
+                TransactionCategory.groceries.key: essentials.id,
+                TransactionCategory.transportation.key: essentials.id,
+            ])
+    }
+}

--- a/FinovaTests/AllocationTagPaletteTests.swift
+++ b/FinovaTests/AllocationTagPaletteTests.swift
@@ -1,0 +1,162 @@
+//
+//  AllocationTagPaletteTests.swift
+//  FinovaTests
+//
+//  The tag palette has to stay legible on the dark budget card AND on the light chip strip, and must
+//  never collide with the colours that already carry meaning on that card. These assertions are the
+//  reason those claims survive a future palette edit.
+//
+
+import UIKit
+import XCTest
+
+@testable import Finova
+
+final class AllocationTagPaletteTests: XCTestCase {
+
+    // MARK: - Contrast helper
+
+    /// WCAG 2.1 relative luminance.
+    private func luminance(_ color: UIColor) -> CGFloat {
+        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+        color.getRed(&r, green: &g, blue: &b, alpha: &a)
+
+        func channel(_ value: CGFloat) -> CGFloat {
+            value <= 0.03928 ? value / 12.92 : pow((value + 0.055) / 1.055, 2.4)
+        }
+        return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b)
+    }
+
+    private func contrast(_ lhs: UIColor, _ rhs: UIColor) -> CGFloat {
+        let l1 = luminance(lhs), l2 = luminance(rhs)
+        return (max(l1, l2) + 0.05) / (min(l1, l2) + 0.05)
+    }
+
+    private func hue(_ color: UIColor) -> CGFloat {
+        var h: CGFloat = 0, s: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+        color.getHue(&h, saturation: &s, brightness: &b, alpha: &a)
+        return h * 360
+    }
+
+    /// The lighter stop of `Colors.gradientBlack`. The ring crosses both stops, so this is the worst
+    /// case for an arc tone - not the near-black one.
+    private let lighterCardStop = UIColor(hex: "#2D2D2D")
+
+    // MARK: - Structure
+
+    func testPaletteHasEightEntries() {
+        XCTAssertEqual(AllocationTagPalette.entries.count, 8)
+        XCTAssertEqual(AllocationTagPalette.count, 8)
+    }
+
+    func testAssignmentOrderIsAPermutationOfEveryIndex() {
+        XCTAssertEqual(
+            AllocationTagPalette.assignmentOrder.sorted(),
+            Array(0..<AllocationTagPalette.count),
+            "every colour must be reachable, and none twice")
+    }
+
+    func testIndexesAreClampedOntoTheTable() {
+        for candidate in [-99, -8, -1, 0, 7, 8, 99] {
+            let clamped = AllocationTagPalette.clampIndex(candidate)
+            XCTAssertTrue((0..<AllocationTagPalette.count).contains(clamped), "\(candidate) -> \(clamped)")
+        }
+    }
+
+    // MARK: - Contrast
+
+    /// A non-text graphical object needs 3:1. Every arc tone must clear that against the *lighter*
+    /// gradient stop, or the ring disappears into the card on one side.
+    func testArcTonesAreLegibleOnTheDarkCard() {
+        for entry in AllocationTagPalette.entries {
+            let ratio = contrast(entry.arc, lighterCardStop)
+            XCTAssertGreaterThanOrEqual(
+                ratio, 3.0, "\(entry.name) arc is \(String(format: "%.2f", ratio)):1 on #2D2D2D")
+        }
+    }
+
+    /// A selected chip fills with its `ink` tone and puts `gray100` text on top, so these have to clear
+    /// the 4.5:1 small-text bar, not just the 3:1 graphical one.
+    func testInkTonesCarryLightTextAndReadOnLightSurfaces() {
+        for entry in AllocationTagPalette.entries {
+            let onSurface = contrast(entry.ink, Colors.gray100)
+            XCTAssertGreaterThanOrEqual(
+                onSurface, 4.5, "\(entry.name) ink is \(String(format: "%.2f", onSurface)):1 on gray100")
+        }
+    }
+
+    /// The tag ring is brighter than the neutrals already on that band, which is what makes it read as
+    /// a chromatic accent rather than more grey.
+    func testArcTonesOutshineTheGreysAlreadyOnTheRing() {
+        let unallocated = contrast(Colors.gray600, lighterCardStop)
+        for entry in AllocationTagPalette.entries {
+            XCTAssertGreaterThan(contrast(entry.arc, lighterCardStop), unallocated, entry.name)
+        }
+    }
+
+    // MARK: - Collisions
+
+    /// Four colours already carry meaning on this exact card: the magenta category ramp, amber
+    /// over-allocation, and the green/red projection verdict. A tag that matched one would be read as
+    /// a status.
+    func testNoPaletteToneCollidesWithAColourThatAlreadyMeansSomething() {
+        let reserved: [(String, UIColor)] = [
+            ("mainMagenta", Colors.mainMagenta),
+            ("warningAmber", Colors.warningAmber),
+            ("brightGreen", Colors.brightGreen),
+            ("brightRed", Colors.brightRed),
+            ("mainRed", Colors.mainRed),
+            ("mainGreen", Colors.mainGreen),
+        ]
+
+        for entry in AllocationTagPalette.entries {
+            for (name, color) in reserved {
+                XCTAssertFalse(
+                    entry.arc.isSameRGB(as: color), "\(entry.name) arc is exactly \(name)")
+                XCTAssertFalse(
+                    entry.ink.isSameRGB(as: color), "\(entry.name) ink is exactly \(name)")
+            }
+        }
+    }
+
+    /// Violet is the closest entry to the magenta category ramp that sits 3pt outside the tag ring, so
+    /// it must be the *last* colour a new tag claims.
+    func testTheHueNearestTheCategoryRampIsClaimedLast() {
+        let magentaHue = hue(Colors.mainMagenta)
+        let distances = AllocationTagPalette.entries.map { entry -> CGFloat in
+            let delta = abs(hue(entry.arc) - magentaHue)
+            return min(delta, 360 - delta)
+        }
+        let nearest = distances.enumerated().min { $0.element < $1.element }!.offset
+
+        XCTAssertEqual(
+            AllocationTagPalette.assignmentOrder.last, nearest,
+            "\(AllocationTagPalette.entries[nearest].name) is nearest mainMagenta and must be assigned last")
+    }
+
+    /// The first few tags are the common case, so they are the ones that have to be unmistakable from
+    /// each other at 7pt.
+    func testTheFirstFourColoursAreWellSpreadInHue() {
+        let firstFour = AllocationTagPalette.assignmentOrder.prefix(4)
+            .map { hue(AllocationTagPalette.entries[$0].arc) }
+
+        for (i, a) in firstFour.enumerated() {
+            for b in firstFour.dropFirst(i + 1) {
+                let delta = abs(a - b)
+                XCTAssertGreaterThan(
+                    min(delta, 360 - delta), 60,
+                    "hues \(Int(a)) and \(Int(b)) are too close for the first four tags")
+            }
+        }
+    }
+}
+
+private extension UIColor {
+    func isSameRGB(as other: UIColor) -> Bool {
+        var r1: CGFloat = 0, g1: CGFloat = 0, b1: CGFloat = 0, a1: CGFloat = 0
+        var r2: CGFloat = 0, g2: CGFloat = 0, b2: CGFloat = 0, a2: CGFloat = 0
+        getRed(&r1, green: &g1, blue: &b1, alpha: &a1)
+        other.getRed(&r2, green: &g2, blue: &b2, alpha: &a2)
+        return abs(r1 - r2) < 0.001 && abs(g1 - g2) < 0.001 && abs(b1 - b2) < 0.001
+    }
+}

--- a/FinovaTests/AllocationTagScenesSnapshotTests.swift
+++ b/FinovaTests/AllocationTagScenesSnapshotTests.swift
@@ -1,0 +1,180 @@
+//
+//  AllocationTagScenesSnapshotTests.swift
+//  FinovaTests
+//
+//  Renders the tag management screens to PNGs so their layout can be reviewed without signing in.
+//  Not an assertion suite beyond "it laid out at all" - it writes attachments and a file per state.
+//
+
+import Foundation
+import UIKit
+import XCTest
+
+@testable import Finova
+
+final class AllocationTagScenesSnapshotTests: XCTestCase {
+
+    private let deviceSize = CGSize(width: 393, height: 852)
+
+    private func render(_ name: String, view: UIView, height: CGFloat? = nil) {
+        // A real window, for the same reason BudgetCardSnapshotTests uses one: rendering a detached
+        // view produces offset or stale output that misrepresents the layout under review.
+        let window = UIWindow(frame: CGRect(origin: .zero, size: deviceSize))
+        window.backgroundColor = Colors.gray200
+        window.isHidden = false
+        window.makeKeyAndVisible()
+
+        view.frame = window.bounds
+        window.addSubview(view)
+        window.setNeedsLayout()
+        window.layoutIfNeeded()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+
+        let size = CGSize(width: deviceSize.width, height: height ?? deviceSize.height)
+        let renderer = UIGraphicsImageRenderer(size: size)
+        let image = renderer.image { context in
+            window.layer.render(in: context.cgContext)
+        }
+
+        guard let data = image.pngData() else {
+            XCTFail("could not encode \(name)")
+            return
+        }
+
+        let attachment = XCTAttachment(data: data, uniformTypeIdentifier: "public.png")
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        add(attachment)
+
+        // A host directory, not NSTemporaryDirectory(): tests run on a throwaway simulator clone whose
+        // sandbox is deleted with it, so anything written there is gone before it can be looked at.
+        // Set FINOVA_SNAPSHOT_DIR to collect the PNGs; the attachment above is always available.
+        guard let directory = ProcessInfo.processInfo.environment["FINOVA_SNAPSHOT_DIR"] else {
+            print("SNAPSHOT_ATTACHED \(name) (\(data.count) bytes); set FINOVA_SNAPSHOT_DIR to save)")
+            return
+        }
+        let url = URL(fileURLWithPath: directory).appendingPathComponent("allocationtags-\(name).png")
+        do {
+            try data.write(to: url)
+            print("SNAPSHOT_WRITTEN \(name) -> \(url.path) (\(data.count) bytes)")
+        } catch {
+            XCTFail("could not write \(name): \(error)")
+        }
+    }
+
+    /// An isolated service so these renders never read or write the developer's own tag book.
+    private func makeService(tagNames: [String], categoriesPerTag: [[TransactionCategory]])
+        -> AllocationTagService
+    {
+        let defaults = UserDefaults(suiteName: "AllocationTagScenesSnapshots.\(UUID().uuidString)")!
+        let uid = "snapshot-uid"
+        let store = UserDefaultsAllocationTagStore(defaults: defaults, uidProvider: { uid })
+        let service = AllocationTagService(store: store, uidProvider: { uid })
+
+        for (index, name) in tagNames.enumerated() {
+            guard let tag = service.createTag(name: name) else { continue }
+            for category in categoriesPerTag[index] {
+                service.assign(categoryKey: category.key, toTagId: tag.id)
+            }
+        }
+        return service
+    }
+
+    func testRenderTagList() {
+        let service = makeService(
+            tagNames: ["Essentials", "Wealth", "Lifestyle"],
+            categoriesPerTag: [
+                [.homeMaintenance, .utilities, .groceries, .transportation],
+                [.investments],
+                [.entertainment, .subscriptions],
+            ])
+
+        let view = AllocationTagsView()
+        let viewModel = AllocationTagsViewModel(tagService: service)
+        let controller = AllocationTagsViewController(
+            contentView: view, viewModel: viewModel, flowDelegate: StubFlowDelegate.shared)
+        controller.loadViewIfNeeded()
+        controller.view.frame = CGRect(origin: .zero, size: deviceSize)
+
+        render("list", view: controller.view)
+
+        XCTAssertEqual(viewModel.tags.count, 3)
+        XCTAssertEqual(viewModel.categoryCount(for: viewModel.tags[0]), 4)
+    }
+
+    func testRenderTagListEmptyState() {
+        let service = makeService(tagNames: [], categoriesPerTag: [])
+
+        let view = AllocationTagsView()
+        let viewModel = AllocationTagsViewModel(tagService: service)
+        let controller = AllocationTagsViewController(
+            contentView: view, viewModel: viewModel, flowDelegate: StubFlowDelegate.shared)
+        controller.loadViewIfNeeded()
+        controller.view.frame = CGRect(origin: .zero, size: deviceSize)
+
+        render("list-empty", view: controller.view)
+
+        XCTAssertTrue(viewModel.isEmpty)
+    }
+
+    func testRenderTagEditForm() {
+        let service = makeService(
+            tagNames: ["Essentials"],
+            categoriesPerTag: [[.homeMaintenance, .utilities, .groceries, .transportation]])
+        guard let tag = service.tags.first else { return XCTFail("no tag") }
+
+        let view = AllocationTagEditView()
+        let controller = AllocationTagEditViewController(
+            contentView: view, tag: tag, tagService: service,
+            flowDelegate: StubFlowDelegate.shared)
+        controller.loadViewIfNeeded()
+        controller.view.frame = CGRect(origin: .zero, size: deviceSize)
+        controller.viewWillAppear(false)
+
+        render("edit", view: controller.view)
+
+        // The colour and icon rows must actually be populated - an empty selector row would still
+        // render as a plausible-looking form.
+        XCTAssertEqual(view.selectedColorIndex, tag.colorIndex)
+        XCTAssertFalse(AllocationTagEditView.iconAssetNames.isEmpty)
+    }
+
+    func testRenderCategoryLinking() {
+        let service = makeService(
+            tagNames: ["Essentials", "Wealth"],
+            categoriesPerTag: [
+                [.homeMaintenance, .utilities, .groceries],
+                [.investments],
+            ])
+        guard let essentials = service.tags.first else { return XCTFail("no tag") }
+
+        let view = AllocationTagCategoriesView()
+        let controller = AllocationTagCategoriesViewController(
+            contentView: view, tag: essentials, tagService: service,
+            flowDelegate: StubFlowDelegate.shared)
+        controller.loadViewIfNeeded()
+        controller.view.frame = CGRect(origin: .zero, size: deviceSize)
+
+        render("categories", view: controller.view)
+    }
+
+    /// Every category offered as a tag icon must resolve to a real asset, or the picker shows blanks.
+    func testEveryOfferedIconAssetExists() {
+        for assetName in AllocationTagEditView.iconAssetNames {
+            XCTAssertNotNil(UIImage(named: assetName), "missing asset \(assetName)")
+        }
+        XCTAssertNotNil(UIImage(systemName: AllocationTag.defaultSymbolName))
+    }
+}
+
+/// Snapshot renders never navigate, so one shared no-op conformer covers all three flows.
+private final class StubFlowDelegate: AllocationTagsFlowDelegate, AllocationTagEditFlowDelegate,
+    AllocationTagCategoriesFlowDelegate
+{
+    static let shared = StubFlowDelegate()
+    func dismissAllocationTags() {}
+    func navigateToAllocationTagEdit(tag: AllocationTag) {}
+    func dismissAllocationTagEdit() {}
+    func navigateToAllocationTagCategories(tag: AllocationTag) {}
+    func dismissAllocationTagCategories() {}
+}

--- a/FinovaTests/AllocationTagSelectionTests.swift
+++ b/FinovaTests/AllocationTagSelectionTests.swift
@@ -1,0 +1,168 @@
+//
+//  AllocationTagSelectionTests.swift
+//  FinovaTests
+//
+//  Which ring a tap on the donut landed on. `chartAngleSelection` yields only an angle, so the radius
+//  is the only thing separating the tag ring from the category ring - this is where that arithmetic is
+//  checked, without SwiftUI in the way.
+//
+
+import CoreGraphics
+import Foundation
+import XCTest
+
+@testable import Finova
+
+@available(iOS 17.0, *)
+final class AllocationTagSelectionTests: XCTestCase {
+
+    /// The real container: 170x170, so a plot radius of 85pt and scale 1.
+    private let plot = CGRect(x: 0, y: 0, width: 170, height: 170)
+    private var centre: CGPoint { CGPoint(x: plot.midX, y: plot.midY) }
+
+    private let essentials = AllocationTag(
+        id: "t-essentials", name: "Essentials", colorIndex: 5, sortOrder: 0)
+    private let wealth = AllocationTag(id: "t-wealth", name: "Wealth", colorIndex: 2, sortOrder: 1)
+
+    /// Essentials 150k (0...0.5), Wealth 100k (0.5...0.833), untagged 30k, headroom 20k. Total 300k.
+    private func breakdown() -> AllocationTagBreakdown {
+        AllocationTagBreakdown(
+            allocations: [
+                BudgetAllocation(
+                    dbId: 1, monthDate: 0, category: .homeMaintenance,
+                    allocatedAmount: 150_000, usedAmount: 0),
+                BudgetAllocation(
+                    dbId: 2, monthDate: 0, category: .investments,
+                    allocatedAmount: 100_000, usedAmount: 0),
+                BudgetAllocation(
+                    dbId: 3, monthDate: 0, category: .travel,
+                    allocatedAmount: 30_000, usedAmount: 0),
+            ],
+            unallocatedSpending: [],
+            unallocatedHeadroom: 20_000,
+            totalBudget: 300_000,
+            tags: [essentials, wealth],
+            categoryTagIds: [
+                TransactionCategory.homeMaintenance.key: essentials.id,
+                TransactionCategory.investments.key: wealth.id,
+            ])
+    }
+
+    /// A point at `radius` from the centre, `fraction` of the way clockwise from 12 o'clock.
+    private func point(radius: CGFloat, fraction: Double) -> CGPoint {
+        let radians = fraction * 2 * .pi - .pi / 2
+        return CGPoint(
+            x: centre.x + radius * CGFloat(cos(radians)),
+            y: centre.y + radius * CGFloat(sin(radians)))
+    }
+
+    /// The angular value Charts would report for a tap at `fraction` around the circle.
+    private func angularValue(_ fraction: Double, in breakdown: AllocationTagBreakdown) -> Int {
+        Int((Double(breakdown.angularTotal) * fraction).rounded())
+    }
+
+    private func resolve(radius: CGFloat, fraction: Double) -> BudgetDonutChartView.Hit {
+        let model = breakdown()
+        return BudgetDonutChartView.resolve(
+            tap: point(radius: radius, fraction: fraction),
+            plot: plot,
+            rawAngleValue: angularValue(fraction, in: model),
+            breakdown: model)
+    }
+
+    // MARK: - Bands
+
+    /// The centre hole. Today a tap here still selects whichever slice shares its angle; ignoring it is
+    /// deliberate, so this test exists to stop someone "restoring" that.
+    func testTapInTheCentreHoleSelectsNothing() {
+        for radius in [CGFloat(0), 20, 40, 50] {
+            XCTAssertEqual(resolve(radius: radius, fraction: 0.25), .none, "r=\(radius)")
+        }
+    }
+
+    func testTapOnTheTagBandSelectsATag() {
+        // 51...66pt is the tag band: the drawn 55...62 widened for fingers.
+        for radius in [CGFloat(52), 55, 58, 62, 65] {
+            XCTAssertEqual(
+                resolve(radius: radius, fraction: 0.25), .tag(essentials.id), "r=\(radius)")
+        }
+    }
+
+    func testTapOnTheCategoryRingSelectsASlice() {
+        for radius in [CGFloat(68), 75, 84] {
+            XCTAssertEqual(
+                resolve(radius: radius, fraction: 0.25),
+                .segment("alloc-homeMaintenance"), "r=\(radius)")
+        }
+    }
+
+    /// The band must stop strictly inside the category ring's 66pt inner edge, or a tap meant for the
+    /// innermost sliver of a slice selects a tag instead.
+    func testTheTwoBandsDoNotOverlap() {
+        XCTAssertEqual(
+            BudgetDonutChartView.tagBandOuterRadius,
+            BudgetDonutChartView.categoryRingInnerRatio * 85,
+            accuracy: 0.5)
+    }
+
+    // MARK: - Angles
+
+    func testEachTagOwnsItsOwnSweep() {
+        // Essentials spans 0...0.5, Wealth 0.5...0.8333.
+        XCTAssertEqual(resolve(radius: 58, fraction: 0.10), .tag(essentials.id))
+        XCTAssertEqual(resolve(radius: 58, fraction: 0.49), .tag(essentials.id))
+        XCTAssertEqual(resolve(radius: 58, fraction: 0.55), .tag(wealth.id))
+        XCTAssertEqual(resolve(radius: 58, fraction: 0.80), .tag(wealth.id))
+    }
+
+    /// The untagged slice and the headroom slice have no arc, so the band is bare there.
+    func testTheBandIsEmptyWhereNoTagReaches() {
+        XCTAssertEqual(resolve(radius: 58, fraction: 0.90), .none)
+        XCTAssertEqual(resolve(radius: 58, fraction: 0.97), .none)
+    }
+
+    func testCategoryRingStillResolvesUntaggedAndHeadroomSlices() {
+        XCTAssertEqual(resolve(radius: 75, fraction: 0.90), .segment("alloc-travel"))
+        XCTAssertEqual(resolve(radius: 75, fraction: 0.97), .segment("headroom"))
+    }
+
+    // MARK: - Degenerate input
+
+    func testAnEmptyBreakdownNeverResolvesToATag() {
+        for radius in [CGFloat(0), 40, 58, 75, 84] {
+            let hit = BudgetDonutChartView.resolve(
+                tap: point(radius: radius, fraction: 0.25),
+                plot: plot, rawAngleValue: 100, breakdown: .empty)
+            if case .tag = hit { XCTFail("empty breakdown resolved to a tag at r=\(radius)") }
+        }
+    }
+
+    func testAZeroSizedPlotResolvesToNothing() {
+        XCTAssertEqual(
+            BudgetDonutChartView.resolve(
+                tap: .zero, plot: .zero, rawAngleValue: 100, breakdown: breakdown()),
+            .none)
+    }
+
+    /// A container sized differently must still hit the right bands - the radii are expressed against
+    /// the 85pt design radius and scaled, not hardcoded in points.
+    func testBandsScaleWithThePlotSize() {
+        let doubled = CGRect(x: 0, y: 0, width: 340, height: 340)
+        let model = breakdown()
+        let centre = CGPoint(x: doubled.midX, y: doubled.midY)
+
+        func hit(radius: CGFloat) -> BudgetDonutChartView.Hit {
+            let radians = 0.25 * 2 * Double.pi - Double.pi / 2
+            let tap = CGPoint(
+                x: centre.x + radius * CGFloat(cos(radians)),
+                y: centre.y + radius * CGFloat(sin(radians)))
+            return BudgetDonutChartView.resolve(
+                tap: tap, plot: doubled,
+                rawAngleValue: angularValue(0.25, in: model), breakdown: model)
+        }
+
+        XCTAssertEqual(hit(radius: 80), .none, "the hole is twice as wide too")
+        XCTAssertEqual(hit(radius: 116), .tag(essentials.id))
+        XCTAssertEqual(hit(radius: 150), .segment("alloc-homeMaintenance"))
+    }
+}

--- a/FinovaTests/AllocationTagStoreTests.swift
+++ b/FinovaTests/AllocationTagStoreTests.swift
@@ -1,0 +1,308 @@
+//
+//  AllocationTagStoreTests.swift
+//  FinovaTests
+//
+//  Persistence of the allocation tag book, and the rules that keep a bad read from becoming data loss.
+//
+
+import Foundation
+import XCTest
+
+@testable import Finova
+
+final class AllocationTagStoreTests: XCTestCase {
+
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+    private var uid: String!
+
+    override func setUp() {
+        super.setUp()
+        // A private suite, never `.standard`: the rest of the app hardcodes standard defaults, and a
+        // test run must not mutate the developer's own state.
+        suiteName = "AllocationTagStoreTests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+        uid = "uid-\(UUID().uuidString)"
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        uid = nil
+        super.tearDown()
+    }
+
+    private func makeStore(uid overrideUid: String? = nil) -> UserDefaultsAllocationTagStore {
+        let resolved = overrideUid ?? uid!
+        return UserDefaultsAllocationTagStore(defaults: defaults, uidProvider: { resolved })
+    }
+
+    private func key(for uid: String) -> String { "allocationTagBook_v1_\(uid)" }
+
+    private func book(
+        tags: [AllocationTag],
+        map: [String: String] = [:]
+    ) -> AllocationTagBook {
+        AllocationTagBook(
+            schemaVersion: AllocationTagBook.currentSchemaVersion,
+            tags: tags,
+            categoryTagIds: map,
+            updatedAt: .distantPast)
+    }
+
+    private func tag(
+        _ id: String,
+        name: String = "Essentials",
+        colorIndex: Int = 0,
+        icon: String? = nil,
+        sortOrder: Int = 0
+    ) -> AllocationTag {
+        AllocationTag(
+            id: id, name: name, colorIndex: colorIndex, iconAssetName: icon, sortOrder: sortOrder)
+    }
+
+    // MARK: - Round trip
+
+    func testEmptyWhenNothingHasBeenSaved() {
+        XCTAssertEqual(makeStore().load(), .empty)
+    }
+
+    func testRoundTripsTagsAndTheCategoryMap() {
+        let store = makeStore()
+        let saved = book(
+            tags: [tag("t1", name: "Essentials", colorIndex: 2, sortOrder: 0)],
+            map: [TransactionCategory.groceries.key: "t1"])
+
+        store.save(saved)
+        let loaded = makeStore().load()
+
+        XCTAssertEqual(loaded.tags.count, 1)
+        XCTAssertEqual(loaded.tags.first?.name, "Essentials")
+        XCTAssertEqual(loaded.tags.first?.colorIndex, 2)
+        XCTAssertEqual(loaded.categoryTagIds[TransactionCategory.groceries.key], "t1")
+    }
+
+    func testSaveStampsUpdatedAt() {
+        let store = makeStore()
+        store.save(book(tags: [tag("t1")]))
+
+        XCTAssertGreaterThan(store.load().updatedAt, .distantPast)
+    }
+
+    func testBooksAreIsolatedPerUid() {
+        let other = "uid-other"
+        makeStore().save(book(tags: [tag("t1", name: "Mine")]))
+        makeStore(uid: other).save(book(tags: [tag("t2", name: "Theirs")]))
+
+        XCTAssertEqual(makeStore().load().tags.first?.name, "Mine")
+        XCTAssertEqual(makeStore(uid: other).load().tags.first?.name, "Theirs")
+    }
+
+    /// Signed out, there is no book. Falling back to an unkeyed slot would leak one account's grouping
+    /// into the next account that signs in on the device.
+    func testNoUidReadsAndWritesNothing() {
+        let store = UserDefaultsAllocationTagStore(defaults: defaults, uidProvider: { nil })
+
+        store.save(book(tags: [tag("t1")]))
+
+        XCTAssertEqual(store.load(), .empty)
+        XCTAssertTrue(defaults.dictionaryRepresentation().keys.allSatisfy {
+            !$0.hasPrefix("allocationTagBook_v1_")
+        })
+    }
+
+    // MARK: - Sanitisation
+
+    func testDropsTagsWithBlankNames() {
+        makeStore().save(book(tags: [tag("t1", name: "  "), tag("t2", name: "Real", sortOrder: 1)]))
+
+        let loaded = makeStore().load()
+        XCTAssertEqual(loaded.tags.map { $0.id }, ["t2"])
+    }
+
+    func testTrimsWhitespaceFromNames() {
+        makeStore().save(book(tags: [tag("t1", name: "  Essentials  ")]))
+
+        XCTAssertEqual(makeStore().load().tags.first?.name, "Essentials")
+    }
+
+    func testClampsAnOutOfRangeColorIndex() {
+        makeStore().save(book(tags: [tag("t1", colorIndex: 99), tag("t2", colorIndex: -3, sortOrder: 1)]))
+
+        let loaded = makeStore().load()
+        for tag in loaded.tags {
+            XCTAssertTrue((0..<AllocationTagPalette.count).contains(tag.colorIndex))
+        }
+    }
+
+    func testNullsOutAnIconAssetThatNoLongerExists() {
+        makeStore().save(book(tags: [tag("t1", icon: "lucide_iconThatDoesNotExist")]))
+
+        let loaded = makeStore().load()
+        XCTAssertNil(loaded.tags.first?.iconAssetName)
+        XCTAssertEqual(loaded.tags.first?.icon, .systemSymbol(AllocationTag.defaultSymbolName))
+    }
+
+    func testKeepsAnIconAssetThatDoesExist() {
+        makeStore().save(book(tags: [tag("t1", icon: "lucide_iconHomeMaintenance")]))
+
+        XCTAssertEqual(makeStore().load().tags.first?.iconAssetName, "lucide_iconHomeMaintenance")
+    }
+
+    func testDropsMapEntriesForUnknownCategories() {
+        makeStore().save(
+            book(
+                tags: [tag("t1")],
+                map: ["notARealCategory": "t1", TransactionCategory.groceries.key: "t1"]))
+
+        let loaded = makeStore().load()
+        XCTAssertEqual(Array(loaded.categoryTagIds.keys), [TransactionCategory.groceries.key])
+    }
+
+    /// The corruption most worth designing out: a link left behind by an interrupted delete.
+    func testDropsMapEntriesPointingAtAMissingTag() {
+        makeStore().save(
+            book(
+                tags: [tag("t1")],
+                map: [
+                    TransactionCategory.groceries.key: "t1",
+                    TransactionCategory.travel.key: "t-deleted",
+                ]))
+
+        let loaded = makeStore().load()
+        XCTAssertEqual(loaded.categoryTagIds[TransactionCategory.groceries.key], "t1")
+        XCTAssertNil(loaded.categoryTagIds[TransactionCategory.travel.key])
+    }
+
+    func testDensifiesSortOrderWhileKeepingRelativeOrder() {
+        makeStore().save(
+            book(tags: [
+                tag("t1", name: "Third", sortOrder: 90),
+                tag("t2", name: "First", sortOrder: 3),
+                tag("t3", name: "Second", sortOrder: 40),
+            ]))
+
+        let loaded = makeStore().load()
+        XCTAssertEqual(loaded.orderedTags.map { $0.name }, ["First", "Second", "Third"])
+        XCTAssertEqual(loaded.orderedTags.map { $0.sortOrder }, [0, 1, 2])
+    }
+
+    func testDropsDuplicateTagIds() {
+        makeStore().save(
+            book(tags: [tag("t1", name: "Keep"), tag("t1", name: "Dupe", sortOrder: 1)]))
+
+        XCTAssertEqual(makeStore().load().tags.count, 1)
+    }
+
+    // MARK: - Untrusted reads
+
+    /// A decode failure must never destroy the bytes it could not read - they may be a newer format or
+    /// the victim of a bug about to be fixed.
+    func testCorruptBlobReadsEmptyAndIsNeverOverwritten() {
+        let corrupt = Data("this is not a tag book".utf8)
+        defaults.set(corrupt, forKey: key(for: uid))
+
+        let store = makeStore()
+        XCTAssertEqual(store.load(), .empty)
+        XCTAssertTrue(store.isReadOnly)
+
+        store.save(book(tags: [tag("t1")]))
+
+        XCTAssertEqual(defaults.data(forKey: key(for: uid)), corrupt, "the unreadable bytes were replaced")
+    }
+
+    /// Only reachable by installing an older build over a newer one.
+    func testANewerSchemaVersionIsReadOnly() throws {
+        let future = AllocationTagBook(
+            schemaVersion: AllocationTagBook.currentSchemaVersion + 1,
+            tags: [tag("t1", name: "FromTheFuture")],
+            categoryTagIds: [:],
+            updatedAt: Date())
+        let encoded = try JSONEncoder().encode(future)
+        defaults.set(encoded, forKey: key(for: uid))
+
+        let store = makeStore()
+        let loaded = store.load()
+
+        XCTAssertEqual(loaded.tags.first?.name, "FromTheFuture", "readable content should still show")
+        XCTAssertTrue(store.isReadOnly)
+
+        store.save(book(tags: []))
+        XCTAssertEqual(defaults.data(forKey: key(for: uid)), encoded)
+    }
+
+    func testReadOnlyClearsOnceTheStoredBookIsValidAgain() {
+        defaults.set(Data("garbage".utf8), forKey: key(for: uid))
+        let store = makeStore()
+        _ = store.load()
+        XCTAssertTrue(store.isReadOnly)
+
+        defaults.removeObject(forKey: key(for: uid))
+        _ = store.load()
+
+        XCTAssertFalse(store.isReadOnly)
+        store.save(book(tags: [tag("t1")]))
+        XCTAssertEqual(store.load().tags.count, 1)
+    }
+
+    func testRemoveBookDeletesOnlyThatUid() {
+        let other = "uid-other"
+        makeStore().save(book(tags: [tag("t1")]))
+        makeStore(uid: other).save(book(tags: [tag("t2")]))
+
+        makeStore().removeBook(forUid: uid)
+
+        XCTAssertEqual(makeStore().load(), .empty)
+        XCTAssertEqual(makeStore(uid: other).load().tags.count, 1)
+    }
+
+    // MARK: - Colour assignment
+
+    func testColoursAreClaimedInAssignmentOrder() {
+        var tags: [AllocationTag] = []
+        var assigned: [Int] = []
+
+        for index in 0..<AllocationTagPalette.count {
+            let next = AllocationTagPalette.nextColorIndex(existing: tags)
+            assigned.append(next)
+            tags.append(tag("t\(index)", colorIndex: next, sortOrder: index))
+        }
+
+        XCTAssertEqual(assigned, AllocationTagPalette.assignmentOrder)
+    }
+
+    func testPastTheEndOfThePaletteColoursWrapToTheLeastUsed() {
+        var tags: [AllocationTag] = []
+        for index in 0..<AllocationTagPalette.count {
+            tags.append(tag("t\(index)", colorIndex: AllocationTagPalette.assignmentOrder[index]))
+        }
+
+        // Every colour used once, so the ninth tag reuses the first in assignment order.
+        let ninth = AllocationTagPalette.nextColorIndex(existing: tags)
+        XCTAssertEqual(ninth, AllocationTagPalette.assignmentOrder.first)
+
+        tags.append(tag("t8", colorIndex: ninth))
+        let tenth = AllocationTagPalette.nextColorIndex(existing: tags)
+        XCTAssertEqual(tenth, AllocationTagPalette.assignmentOrder[1])
+    }
+
+    /// Deleting a tag frees its colour, which is what a user expects when they delete and recreate.
+    func testDeletingATagFreesItsColourForTheNextOne() {
+        var tags = (0..<4).map {
+            tag("t\($0)", colorIndex: AllocationTagPalette.assignmentOrder[$0], sortOrder: $0)
+        }
+        let freed = tags[2].colorIndex
+        tags.remove(at: 2)
+
+        XCTAssertEqual(AllocationTagPalette.nextColorIndex(existing: tags), freed)
+    }
+
+    func testColourAssignmentIgnoresOutOfRangeStoredIndexes() {
+        let tags = [tag("t1", colorIndex: AllocationTagPalette.count)]  // clamps to 0
+
+        XCTAssertNotEqual(
+            AllocationTagPalette.nextColorIndex(existing: tags), 0,
+            "an index that clamps to 0 must still count as using colour 0")
+    }
+}

--- a/FinovaTests/AllocationTagStripSnapshotTests.swift
+++ b/FinovaTests/AllocationTagStripSnapshotTests.swift
@@ -59,8 +59,8 @@ final class AllocationTagStripSnapshotTests: XCTestCase {
     }
 
     /// Builds the header + strip + table stack the way `MonthCarouselCell` does, without the carousel.
-    private func render(_ name: String, selectedTagId: String?) {
-        let model = breakdown()
+    private func render(_ name: String, selectedTagId: String?, singleTag: Bool = false) {
+        let model = singleTag ? singleTagBreakdown() : breakdown()
 
         let header = UIStackView()
         header.axis = .horizontal
@@ -74,12 +74,18 @@ final class AllocationTagStripSnapshotTests: XCTestCase {
         header.distribution = .equalSpacing
         header.translatesAutoresizingMaskIntoConstraints = false
 
+        // Mirrors the cell: title + count grouped at the leading edge, Tags button at the trailing one.
+        let leading = UIStackView()
+        leading.axis = .horizontal
+        leading.alignment = .center
+        leading.spacing = Metrics.spacing2
+
         let title = UILabel()
         title.fontStyle = Fonts.title2XS
         title.textColor = Colors.gray500
         title.text = "budget.allocations.title".localized
         title.applyStyle()
-        header.addArrangedSubview(title)
+        leading.addArrangedSubview(title)
 
         let visibleAllocations =
             selectedTagId == nil
@@ -88,11 +94,33 @@ final class AllocationTagStripSnapshotTests: XCTestCase {
                 .sorted { $0.allocatedAmount > $1.allocatedAmount }
                 .filter { model.segment("alloc-\($0.category.key)", belongsTo: selectedTagId!) }
 
+        // The real count pill, not a bare label: re-parenting it into the leading group could have
+        // broken the circular background, whose radius is derived from its own bounds.
+        let countPill = UIStackView()
+        countPill.axis = .horizontal
+        countPill.distribution = .fillEqually
+        countPill.alignment = .center
+        countPill.backgroundColor = Colors.gray300
+        countPill.clipsToBounds = true
+        countPill.layoutMargins = UIEdgeInsets(
+            top: 0, left: Metrics.spacing2, bottom: 0, right: Metrics.spacing2)
+        countPill.isLayoutMarginsRelativeArrangement = true
+        countPill.heightAnchor.constraint(equalToConstant: 18).isActive = true
+
         let countLabel = UILabel()
         countLabel.font = Fonts.titleXS.font
         countLabel.textColor = Colors.gray600
+        countLabel.textAlignment = .center
         countLabel.text = "\(visibleAllocations.count)"
-        header.addArrangedSubview(countLabel)
+        countPill.addArrangedSubview(countLabel)
+        leading.addArrangedSubview(countPill)
+        header.addArrangedSubview(leading)
+
+        let tagsButton = UIButton(type: .system)
+        tagsButton.setTitle("budgets.tags.manage".localized, for: .normal)
+        tagsButton.titleLabel?.font = Fonts.titleXS.font
+        tagsButton.setTitleColor(Colors.mainMagenta, for: .normal)
+        header.addArrangedSubview(tagsButton)
 
         let strip = AllocationTagStripView()
         strip.translatesAutoresizingMaskIntoConstraints = false
@@ -152,6 +180,7 @@ final class AllocationTagStripSnapshotTests: XCTestCase {
         window.layoutIfNeeded()
         table.reloadData()
         window.layoutIfNeeded()
+        countPill.layer.cornerRadius = countPill.bounds.height / 2
         RunLoop.current.run(until: Date().addingTimeInterval(0.1))
 
         let size = CGSize(width: width, height: totalHeight + 40)
@@ -173,9 +202,23 @@ final class AllocationTagStripSnapshotTests: XCTestCase {
         print("SNAPSHOT_WRITTEN \(name)")
     }
 
+    /// One tag, so the Untagged chip and the trailing `+` both fit on screen without scrolling - the
+    /// three- and four-chip cases push the `+` past the right edge, which is why the header also carries
+    /// a Tags button.
+    private func singleTagBreakdown() -> AllocationTagBreakdown {
+        AllocationTagBreakdown(
+            allocations: allocations(),
+            unallocatedSpending: [],
+            unallocatedHeadroom: 100_000,
+            totalBudget: 1_000_000,
+            tags: [essentials],
+            categoryTagIds: [TransactionCategory.homeMaintenance.key: essentials.id])
+    }
+
     func testRenderStripStates() {
         render("unfiltered", selectedTagId: nil)
         render("filtered", selectedTagId: essentials.id)
+        render("single-tag", selectedTagId: nil, singleTag: true)
     }
 
     /// A month with no tags must produce no strip, so the caller collapses its height to zero and the

--- a/FinovaTests/AllocationTagStripSnapshotTests.swift
+++ b/FinovaTests/AllocationTagStripSnapshotTests.swift
@@ -1,0 +1,219 @@
+//
+//  AllocationTagStripSnapshotTests.swift
+//  FinovaTests
+//
+//  Renders the chip strip in place between the allocations header and the table, so the three-part
+//  rounded card, the borders and the filtered list can be reviewed without signing in.
+//
+
+import Foundation
+import UIKit
+import XCTest
+
+@testable import Finova
+
+final class AllocationTagStripSnapshotTests: XCTestCase {
+
+    private let width: CGFloat = 343  // 375pt device: the tightest layout
+
+    private let essentials = AllocationTag(
+        id: "t-essentials", name: "Essentials", colorIndex: 5, sortOrder: 0)
+    private let wealth = AllocationTag(id: "t-wealth", name: "Wealth", colorIndex: 2, sortOrder: 1)
+    private let lifestyle = AllocationTag(
+        id: "t-lifestyle", name: "Lifestyle", colorIndex: 3, sortOrder: 2)
+
+    private func allocations() -> [BudgetAllocation] {
+        [
+            BudgetAllocation(
+                dbId: 1, monthDate: 0, category: .investments,
+                allocatedAmount: 560_000, usedAmount: 560_000),
+            BudgetAllocation(
+                dbId: 2, monthDate: 0, category: .homeMaintenance,
+                allocatedAmount: 200_000, usedAmount: 200_000),
+            BudgetAllocation(
+                dbId: 3, monthDate: 0, category: .groceries,
+                allocatedAmount: 60_000, usedAmount: 48_000),
+            BudgetAllocation(
+                dbId: 4, monthDate: 0, category: .entertainment,
+                allocatedAmount: 50_000, usedAmount: 42_000),
+            BudgetAllocation(
+                dbId: 5, monthDate: 0, category: .travel,
+                allocatedAmount: 30_000, usedAmount: 5_000),
+        ]
+    }
+
+    private func breakdown() -> AllocationTagBreakdown {
+        AllocationTagBreakdown(
+            allocations: allocations(),
+            unallocatedSpending: [],
+            unallocatedHeadroom: 100_000,
+            totalBudget: 1_000_000,
+            tags: [essentials, wealth, lifestyle],
+            categoryTagIds: [
+                TransactionCategory.investments.key: wealth.id,
+                TransactionCategory.homeMaintenance.key: essentials.id,
+                TransactionCategory.groceries.key: essentials.id,
+                TransactionCategory.entertainment.key: lifestyle.id,
+                // .travel deliberately untagged, so the Untagged chip appears
+            ])
+    }
+
+    /// Builds the header + strip + table stack the way `MonthCarouselCell` does, without the carousel.
+    private func render(_ name: String, selectedTagId: String?) {
+        let model = breakdown()
+
+        let header = UIStackView()
+        header.axis = .horizontal
+        header.alignment = .center
+        header.backgroundColor = Colors.gray100
+        header.layer.cornerRadius = CornerRadius.extraLarge
+        header.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+        header.layoutMargins = UIEdgeInsets(
+            top: 0, left: Metrics.spacing5, bottom: 0, right: Metrics.spacing4)
+        header.isLayoutMarginsRelativeArrangement = true
+        header.distribution = .equalSpacing
+        header.translatesAutoresizingMaskIntoConstraints = false
+
+        let title = UILabel()
+        title.fontStyle = Fonts.title2XS
+        title.textColor = Colors.gray500
+        title.text = "budget.allocations.title".localized
+        title.applyStyle()
+        header.addArrangedSubview(title)
+
+        let visibleAllocations =
+            selectedTagId == nil
+            ? allocations().sorted { $0.allocatedAmount > $1.allocatedAmount }
+            : allocations()
+                .sorted { $0.allocatedAmount > $1.allocatedAmount }
+                .filter { model.segment("alloc-\($0.category.key)", belongsTo: selectedTagId!) }
+
+        let countLabel = UILabel()
+        countLabel.font = Fonts.titleXS.font
+        countLabel.textColor = Colors.gray600
+        countLabel.text = "\(visibleAllocations.count)"
+        header.addArrangedSubview(countLabel)
+
+        let strip = AllocationTagStripView()
+        strip.translatesAutoresizingMaskIntoConstraints = false
+        let hasStrip = strip.configure(
+            breakdown: model, selectedTagId: selectedTagId, isValuesHidden: false)
+        XCTAssertTrue(hasStrip, "three tags should produce a strip")
+
+        let table = UITableView()
+        table.backgroundColor = Colors.gray100
+        table.layer.borderWidth = 1
+        table.layer.borderColor = Colors.gray300.cgColor
+        table.layer.cornerRadius = CornerRadius.extraLarge
+        table.layer.maskedCorners = [.layerMinXMaxYCorner, .layerMaxXMaxYCorner]
+        table.separatorStyle = .singleLine
+        table.separatorInset = .zero
+        table.separatorColor = Colors.gray300
+        table.clipsToBounds = true
+        table.isScrollEnabled = false
+        table.translatesAutoresizingMaskIntoConstraints = false
+        table.register(AllocationCell.self, forCellReuseIdentifier: AllocationCell.reuseIdentifier)
+
+        let source = StubTableSource(allocations: visibleAllocations)
+        table.dataSource = source
+        table.delegate = source
+
+        let tableHeight = CGFloat(visibleAllocations.count) * 68
+        let totalHeight = Metrics.spacing11 + AllocationTagStripView.preferredHeight + tableHeight
+
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: width, height: totalHeight + 40))
+        window.backgroundColor = Colors.gray200
+        window.isHidden = false
+        window.makeKeyAndVisible()
+
+        let host = UIView(frame: window.bounds)
+        host.backgroundColor = Colors.gray200
+        window.addSubview(host)
+        [header, strip, table].forEach { host.addSubview($0) }
+
+        NSLayoutConstraint.activate([
+            header.topAnchor.constraint(equalTo: host.topAnchor, constant: 20),
+            header.leadingAnchor.constraint(equalTo: host.leadingAnchor),
+            header.trailingAnchor.constraint(equalTo: host.trailingAnchor),
+            header.heightAnchor.constraint(equalToConstant: Metrics.spacing11),
+
+            strip.topAnchor.constraint(equalTo: header.bottomAnchor),
+            strip.leadingAnchor.constraint(equalTo: host.leadingAnchor),
+            strip.trailingAnchor.constraint(equalTo: host.trailingAnchor),
+            strip.heightAnchor.constraint(equalToConstant: AllocationTagStripView.preferredHeight),
+
+            table.topAnchor.constraint(equalTo: strip.bottomAnchor),
+            table.leadingAnchor.constraint(equalTo: host.leadingAnchor),
+            table.trailingAnchor.constraint(equalTo: host.trailingAnchor),
+            table.heightAnchor.constraint(equalToConstant: tableHeight),
+        ])
+
+        window.setNeedsLayout()
+        window.layoutIfNeeded()
+        table.reloadData()
+        window.layoutIfNeeded()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+
+        let size = CGSize(width: width, height: totalHeight + 40)
+        let renderer = UIGraphicsImageRenderer(size: size)
+        let image = renderer.image { context in
+            window.layer.render(in: context.cgContext)
+        }
+
+        guard let data = image.pngData() else { return XCTFail("could not encode \(name)") }
+
+        let attachment = XCTAttachment(data: data, uniformTypeIdentifier: "public.png")
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        add(attachment)
+
+        guard let directory = ProcessInfo.processInfo.environment["FINOVA_SNAPSHOT_DIR"] else { return }
+        try? data.write(
+            to: URL(fileURLWithPath: directory).appendingPathComponent("tagstrip-\(name).png"))
+        print("SNAPSHOT_WRITTEN \(name)")
+    }
+
+    func testRenderStripStates() {
+        render("unfiltered", selectedTagId: nil)
+        render("filtered", selectedTagId: essentials.id)
+    }
+
+    /// A month with no tags must produce no strip, so the caller collapses its height to zero and the
+    /// table sits directly under the header exactly as it did before.
+    func testNoTagsProducesNoStrip() {
+        let strip = AllocationTagStripView()
+        let tagless = AllocationTagBreakdown(
+            allocations: allocations(),
+            unallocatedSpending: [],
+            unallocatedHeadroom: 100_000,
+            totalBudget: 1_000_000,
+            tags: [],
+            categoryTagIds: [:])
+
+        XCTAssertFalse(
+            strip.configure(breakdown: tagless, selectedTagId: nil, isValuesHidden: false))
+    }
+}
+
+private final class StubTableSource: NSObject, UITableViewDataSource, UITableViewDelegate {
+    private let allocations: [BudgetAllocation]
+
+    init(allocations: [BudgetAllocation]) {
+        self.allocations = allocations
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        allocations.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard
+            let cell = tableView.dequeueReusableCell(
+                withIdentifier: AllocationCell.reuseIdentifier, for: indexPath) as? AllocationCell
+        else { return UITableViewCell() }
+        cell.configure(with: allocations[indexPath.row])
+        return cell
+    }
+
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat { 68 }
+}

--- a/FinovaTests/BudgetCardSnapshotTests.swift
+++ b/FinovaTests/BudgetCardSnapshotTests.swift
@@ -58,7 +58,8 @@ final class BudgetCardSnapshotTests: XCTestCase {
         allocations: [BudgetAllocation],
         usedValue: Int = 150_000,
         budgetLimit: Int? = 350_000,
-        unallocatedSpending: Int = 18_000
+        unallocatedSpending: Int = 18_000,
+        tagBreakdown: AllocationTagBreakdown = .empty
     ) {
         let card = BudgetCard()
         card.translatesAutoresizingMaskIntoConstraints = false
@@ -94,7 +95,8 @@ final class BudgetCardSnapshotTests: XCTestCase {
             monthAnchor: monthAnchor,
             monthData: makeMonthData(
                 finalBalance, anchor: monthAnchor,
-                usedValue: usedValue, budgetLimit: budgetLimit)
+                usedValue: usedValue, budgetLimit: budgetLimit),
+            tagBreakdown: tagBreakdown
         )
 
         window.setNeedsLayout()
@@ -118,7 +120,11 @@ final class BudgetCardSnapshotTests: XCTestCase {
         attachment.lifetime = .keepAlways
         add(attachment)
 
-        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+        // A host directory when one is given: tests run on a throwaway simulator clone whose sandbox
+        // goes away with it, so NSTemporaryDirectory() output is gone before it can be looked at.
+        let directory =
+            ProcessInfo.processInfo.environment["FINOVA_SNAPSHOT_DIR"] ?? NSTemporaryDirectory()
+        let url = URL(fileURLWithPath: directory)
             .appendingPathComponent("budgetcard-\(name).png")
         do {
             try data.write(to: url)
@@ -196,6 +202,60 @@ final class BudgetCardSnapshotTests: XCTestCase {
             name: "gauge-absent", finalBalance: 428_000,
             monthAnchor: currentMonthAnchor, allocations: allocations(),
             usedValue: 300_000, budgetLimit: nil)
+    }
+
+    // MARK: - Tag ring
+
+    /// Two tags over the four allocations, plus one category left untagged.
+    private func twoTagBreakdown() -> AllocationTagBreakdown {
+        let essentials = AllocationTag(
+            id: "t-essentials", name: "Essentials", colorIndex: 5, sortOrder: 0)
+        let wealth = AllocationTag(id: "t-wealth", name: "Wealth", colorIndex: 2, sortOrder: 1)
+
+        return AllocationTagBreakdown(
+            allocations: allocations(),
+            unallocatedSpending: [],
+            unallocatedHeadroom: 107_000,
+            totalBudget: 350_000,
+            tags: [essentials, wealth],
+            categoryTagIds: [
+                TransactionCategory.meals.key: essentials.id,
+                TransactionCategory.utilities.key: essentials.id,
+                TransactionCategory.savings.key: wealth.id,
+                // .transportation deliberately left untagged
+            ])
+    }
+
+    /// `tags-none` must be pixel-identical to `projected`: with no tags the category ring keeps its
+    /// original 85...55pt geometry and no ring is drawn.
+    ///
+    /// That equality covers geometry, not slice order. `AllocationTagBreakdown` sorts allocations
+    /// amount-desc, and this fixture deliberately passes them unsorted (transportation before savings),
+    /// so these renders differ from a pre-tag build's - by exactly that reordering. See the note on
+    /// `AllocationTagBreakdown.sortedSegments`.
+    func testRenderTagRingStates() {
+        render(
+            name: "tags-none", finalBalance: 428_000,
+            monthAnchor: currentMonthAnchor, allocations: allocations())
+
+        render(
+            name: "tags-two", finalBalance: 428_000,
+            monthAnchor: currentMonthAnchor, allocations: allocations(),
+            tagBreakdown: twoTagBreakdown())
+
+        // One tag covering everything: the ring should be a single near-complete arc.
+        let all = AllocationTag(id: "t-all", name: "Everything", colorIndex: 3, sortOrder: 0)
+        render(
+            name: "tags-one", finalBalance: 428_000,
+            monthAnchor: currentMonthAnchor, allocations: allocations(),
+            tagBreakdown: AllocationTagBreakdown(
+                allocations: allocations(),
+                unallocatedSpending: [],
+                unallocatedHeadroom: 107_000,
+                totalBudget: 350_000,
+                tags: [all],
+                categoryTagIds: Dictionary(
+                    uniqueKeysWithValues: allocations().map { ($0.category.key, all.id) })))
     }
 
     func testRenderHiddenValuesState() {

--- a/FinovaTests/BudgetCardSnapshotTests.swift
+++ b/FinovaTests/BudgetCardSnapshotTests.swift
@@ -59,7 +59,8 @@ final class BudgetCardSnapshotTests: XCTestCase {
         usedValue: Int = 150_000,
         budgetLimit: Int? = 350_000,
         unallocatedSpending: Int = 18_000,
-        tagBreakdown: AllocationTagBreakdown = .empty
+        tagBreakdown: AllocationTagBreakdown = .empty,
+        selectedTagId: String? = nil
     ) {
         let card = BudgetCard()
         card.translatesAutoresizingMaskIntoConstraints = false
@@ -98,6 +99,7 @@ final class BudgetCardSnapshotTests: XCTestCase {
                 usedValue: usedValue, budgetLimit: budgetLimit),
             tagBreakdown: tagBreakdown
         )
+        card.setSelectedTag(selectedTagId)
 
         window.setNeedsLayout()
         window.layoutIfNeeded()
@@ -242,6 +244,13 @@ final class BudgetCardSnapshotTests: XCTestCase {
             name: "tags-two", finalBalance: 428_000,
             monthAnchor: currentMonthAnchor, allocations: allocations(),
             tagBreakdown: twoTagBreakdown())
+
+        // Essentials selected: its two slices stay lit, everything else dims, and the centre swaps to
+        // the tag's own name, subtotal and share.
+        render(
+            name: "tags-selected", finalBalance: 428_000,
+            monthAnchor: currentMonthAnchor, allocations: allocations(),
+            tagBreakdown: twoTagBreakdown(), selectedTagId: "t-essentials")
 
         // One tag covering everything: the ring should be a single near-complete arc.
         let all = AllocationTag(id: "t-all", name: "Everything", colorIndex: 3, sortOrder: 0)


### PR DESCRIPTION
Ports the allocation-tags feature from `release/v1.6.0` (merged there in a9514f9) onto the 1.5.0 line.

## What the feature does

Groups spending categories into user-created tags, so the budget card can report what a whole set of them costs in a month — the sub-budget figure the per-category donut cannot answer. A tag binds to the **category**, not the allocation row, so off-plan spending lands in its tag for free and nobody answers the same question twelve times a year.

- A thin tag ring inside the donut, and a chip strip of per-tag subtotals under the card that doubles as a filter
- Tag management reached two ways: a **Tags** button on the allocations header, and a **+** chip at the end of the strip
- Tag catalog persists as a per-uid JSON blob behind `AllocationTagStoring`. **CloudKit sync is deliberately deferred**, so tags are device-local

## How the port was done

Cherry-picked the 7 feature commits rather than merging the branch — merging would have dragged in all 97 commits of 1.6.0 divergence. Most of it applied untouched, because `AllocationBalanceProjection`, `BudgetDonutChartView`, `BudgetsView` and every new file are byte-identical across the two release branches.

**One code adaptation.** `LedgerScope` arrives with group sync in 1.6.0 and does not exist here, so `rebuildAllocationsUI` calls the scope-free service signatures. Everything is personal-scoped, which is what the rest of `MonthCarouselCell` already assumes on this branch.

**Three conflicts resolved by deliberately not taking the incoming side wholesale**, since each would have imported 1.6.0 surface into 1.5.0:

| File | Kept |
|---|---|
| `Notification+Ext` | only `allocationTagsChanged`, not the 12 group-sync names |
| `ViewControllersFactory` | only the 3 tag factory methods, not the 5 group/sync ones |
| `DashboardFlowDelegate` | 1.5.0's `openAdjustBalanceModal(currentBalance:)`, without `DataContext` |

The string catalog needed a second pass (6125e86). 1.6.0's copy happens to be alphabetically sorted and 1.5.0's is not — by no collation I could reproduce — so resolving it with a global sort rewrote two thirds of the file. The 33 new keys are appended instead: 561 insertions, no deletions.

## Also carried over

Three fixes found while building the feature, which apply here for the same reasons:

- The donut drew slices in service order while the list beneath showed them by amount. They agree now — this is the one visible change for a user who never makes a tag.
- The centre readout drew a selected category's icon through the ring's brightness-by-size ramp, so the smallest category's icon rendered near-black on a near-black card.
- The projection bar plotted plan adherence, which came out almost entirely green on any well-behaved month and read as "everything is saved". It is now three segments: projection in magenta, saved in green, overspent in red.

## Verification

Builds clean on `Finova.xcworkspace`. All 9 feature suites pass on this branch: breakdown, store, palette, selection, the two snapshot suites, plus `AllocationBalanceProjectionTests`, `BudgetCardLayoutTests` and `BudgetCardSnapshotTests` — including the card's 295pt height assertion and the projection-blocks-clear-the-donut check.

Not verified by me: a manual pass on device. `autoLoginEnabled` is `false` in `SplashViewController`, so every render in development was headless.

Pre-existing and unrelated: `NotificationTests`, `SyncEngineTests`, `TransactionLogicTests` and `AuthenticationTests.testFaceIDUserManagement` fail identically before this work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)